### PR TITLE
feat: add topics and mentions destroy action

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -20,6 +20,8 @@ module API
       rescue_from Warden::JWTAuth::Errors::RevokedToken, with: :render_unauthorized
       rescue_from JWT::ExpiredSignature,               with: :render_unauthorized
       rescue_from JWT::DecodeError,                    with: :render_unauthorized
+      rescue_from ActiveRecord::RecordNotDestroyed,    with: :render_record_not_destroyed
+      rescue_from ActiveRecord::DeleteRestrictionError, with: :render_restriction_error
 
       private
 
@@ -46,6 +48,14 @@ module API
 
       def render_unauthorized(exception)
         render_error(exception, { message: I18n.t('api.errors.unauthorized') }, :unauthorized)
+      end
+
+      def render_record_not_destroyed(exception)
+        render_error(exception, { message: I18n.t('api.errors.record_not_destroyed') }, :conflict)
+      end
+
+      def render_restriction_error(exception)
+        render_error(exception, { message: I18n.t('api.errors.deletion_restricted') }, :conflict)
       end
     end
   end

--- a/app/controllers/api/v1/mentions_controller.rb
+++ b/app/controllers/api/v1/mentions_controller.rb
@@ -3,7 +3,8 @@
 module API
   module V1
     class MentionsController < API::V1::APIController
-      before_action :set_mention, only: %i[update]
+      before_action :set_mention, only: %i[update destroy]
+
       def index
         @mentions = policy_scope(Mention).ordered
       end
@@ -18,6 +19,12 @@ module API
         authorize @mention
         @mention.update!(mention_params)
         render :show, status: :ok
+      end
+
+      def destroy
+        authorize @mention
+        @mention.destroy!
+        head :no_content
       end
 
       private

--- a/app/controllers/api/v1/topics_controller.rb
+++ b/app/controllers/api/v1/topics_controller.rb
@@ -3,7 +3,8 @@
 module API
   module V1
     class TopicsController < API::V1::APIController
-      before_action :set_topic, only: %i[update]
+      before_action :set_topic, only: %i[update destroy]
+
       def index
         @topics = policy_scope(Topic).ordered
       end
@@ -18,6 +19,12 @@ module API
         authorize @topic
         @topic.update!(topic_params)
         render :show, status: :ok
+      end
+
+      def destroy
+        authorize @topic
+        @topic.destroy!
+        head :no_content
       end
 
       private

--- a/app/models/mention.rb
+++ b/app/models/mention.rb
@@ -16,7 +16,7 @@
 #
 
 class Mention < ApplicationRecord
-  has_many :mention_news, dependent: :destroy
+  has_many :mention_news, dependent: :restrict_with_exception
   has_many :news, through: :mention_news
 
   validates :name, presence: true, uniqueness: true

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -17,7 +17,7 @@
 #  index_topics_on_name  (name) UNIQUE
 #
 class Topic < ApplicationRecord
-  has_many :news, dependent: :restrict_with_error
+  has_many :news, dependent: :restrict_with_exception
 
   validates :name, presence: true, uniqueness: true
 
@@ -33,5 +33,3 @@ class Topic < ApplicationRecord
     news.valuation_negative.count > 5
   end
 end
-
-# TODO: como max 5 temas activas.

--- a/app/policies/mention_policy.rb
+++ b/app/policies/mention_policy.rb
@@ -6,4 +6,6 @@ class MentionPolicy < ApplicationPolicy
   def create? = true
 
   def update? = true
+
+  def destroy? = true
 end

--- a/app/policies/topic_policy.rb
+++ b/app/policies/topic_policy.rb
@@ -6,4 +6,6 @@ class TopicPolicy < ApplicationPolicy
   def create? = true
 
   def update? = true
+
+  def destroy? = true
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,3 +13,5 @@ en:
       forbidden: You are not allowed to perform this action
       unauthorized: You are not authenticated or your token has expired
       invalid_credentials: Invalid credentials
+      record_not_destroyed: Couldn't destroy the record
+      deletion_restricted: Deletion is restricted due to dependent associations

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -8,3 +8,5 @@ es:
       forbidden: No tenés permisos para realizar esta acción 
       unauthorized: No estás autenticado o tu token expiró
       invalid_credentials: Credenciales inválidas
+      record_not_destroyed: No se pudo eliminar el registro
+      deletion_restricted: La eliminación está restringida debido a asociaciones dependientes

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -145,7 +145,7 @@ Rails.application.routes.draw do
         resource :user, only: %i[update show]
       end
       resources :users, only: %i[index show create update destroy]
-      resources :topics, only: %i[index create update]
+      resources :topics, only: %i[index create update destroy]
       resources :news, only: %i[index] do
         post :batch_process, on: :collection
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -149,7 +149,7 @@ Rails.application.routes.draw do
       resources :news, only: %i[index] do
         post :batch_process, on: :collection
       end
-      resources :mentions, only: %i[index create update]
+      resources :mentions, only: %i[index create update destroy]
       resources :settings, only: [] do
         get :must_update, on: :collection
       end

--- a/spec/models/mention_spec.rb
+++ b/spec/models/mention_spec.rb
@@ -2,7 +2,7 @@
 
 describe Mention do
   describe 'associations' do
-    it { is_expected.to have_many(:mention_news).dependent(:destroy) }
+    it { is_expected.to have_many(:mention_news).dependent(:restrict_with_exception) }
     it { is_expected.to have_many(:news).through(:mention_news) }
   end
 

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -4,7 +4,7 @@
 
 describe Topic do
   describe 'associations' do
-    it { is_expected.to have_many(:news).dependent(:restrict_with_error) }
+    it { is_expected.to have_many(:news).dependent(:restrict_with_exception) }
   end
 
   describe 'validations' do

--- a/spec/requests/api/v1/mentions/destroy_spec.rb
+++ b/spec/requests/api/v1/mentions/destroy_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+describe 'DELETE api/v1/mentions/:id' do
+  let!(:mention) { create(:mention) }
+
+  context 'when authenticated as admin user' do
+    include_context 'with authenticated admin user via JWT'
+
+    context 'when destroying an existing mention without dependencies' do
+      subject { delete "/api/v1/mentions/#{mention.id}", headers: auth_headers }
+
+      it 'returns no content status' do
+        subject
+        expect(response).to have_http_status(:no_content)
+      end
+
+      it 'destroys the mention' do
+        expect { subject }.to change(Mention, :count).by(-1)
+        expect { mention.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it 'returns empty body' do
+        subject
+        expect(response.body).to be_empty
+      end
+    end
+
+    context 'when destroying a mention with dependent news (restricted)' do
+      subject { delete "/api/v1/mentions/#{restricted_mention.id}", headers: auth_headers }
+
+      let!(:restricted_mention) { create(:mention, :with_news) }
+
+      it 'returns conflict status' do
+        subject
+        expect(response).to have_http_status(:conflict)
+      end
+
+      it 'does not destroy the mention' do
+        expect { subject }.not_to change(Mention, :count)
+        expect(restricted_mention.reload).to be_present
+      end
+
+      it 'returns error message' do
+        subject
+        expect(json[:errors]).to be_present
+        expect(json[:errors].first[:message]).to be_present
+      end
+    end
+
+    context 'when record is not found' do
+      subject { delete '/api/v1/mentions/999999', headers: auth_headers }
+
+      it 'returns status 404 not found' do
+        subject
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it 'returns error message' do
+        subject
+        expect(json[:errors]).to be_present
+        expect(json[:errors].first[:message]).to be_present
+      end
+    end
+  end
+
+  context 'when authenticated as regular user' do
+    include_context 'with authenticated regular user via JWT'
+
+    context 'when destroying an existing mention' do
+      subject { delete "/api/v1/mentions/#{mention.id}", headers: auth_headers }
+
+      it 'returns no content status' do
+        subject
+        expect(response).to have_http_status(:no_content)
+      end
+
+      it 'destroys the mention' do
+        expect { subject }.to change(Mention, :count).by(-1)
+      end
+    end
+
+    context 'when destroying a mention with dependent news (restricted)' do
+      subject { delete "/api/v1/mentions/#{restricted_mention.id}", headers: auth_headers }
+
+      let!(:restricted_mention) { create(:mention, :with_news) }
+
+      it 'returns conflict status' do
+        subject
+        expect(response).to have_http_status(:conflict)
+      end
+
+      it 'does not destroy the mention' do
+        expect { subject }.not_to change(Mention, :count)
+      end
+    end
+  end
+
+  context 'when not authenticated' do
+    subject { delete "/api/v1/mentions/#{mention.id}", headers: auth_headers }
+
+    let(:auth_headers) { {} }
+
+    it 'returns unauthorized status' do
+      subject
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'does not destroy the mention' do
+      expect { subject }.not_to change(Mention, :count)
+      expect(mention.reload).to be_present
+    end
+
+    it 'returns error message' do
+      subject
+      expect(json[:errors]).to be_present
+      expect(json[:errors].first[:message]).to be_present
+    end
+  end
+
+  context 'when authenticated with invalid token' do
+    subject { delete "/api/v1/mentions/#{mention.id}", headers: auth_headers }
+
+    let(:auth_headers) { { 'Authorization' => 'Bearer invalid_token' } }
+
+    it 'returns unauthorized status' do
+      subject
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'does not destroy the mention' do
+      expect { subject }.not_to change(Mention, :count)
+      expect(mention.reload).to be_present
+    end
+
+    it 'returns error message' do
+      subject
+      expect(json[:errors]).to be_present
+      expect(json[:errors].first[:message]).to be_present
+    end
+  end
+end

--- a/spec/requests/api/v1/topics/destroy_spec.rb
+++ b/spec/requests/api/v1/topics/destroy_spec.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+describe 'DELETE api/v1/topics/:id' do
+  let!(:topic) { create(:topic) }
+
+  context 'when authenticated as admin user' do
+    include_context 'with authenticated admin user via JWT'
+
+    context 'when destroying an existing topic without dependencies' do
+      subject { delete "/api/v1/topics/#{topic.id}", headers: auth_headers }
+
+      it 'returns no content status' do
+        subject
+        expect(response).to have_http_status(:no_content)
+      end
+
+      it 'destroys the topic' do
+        expect { subject }.to change(Topic, :count).by(-1)
+        expect { topic.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it 'returns empty body' do
+        subject
+        expect(response.body).to be_empty
+      end
+    end
+
+    context 'when destroying a topic with dependent news (restricted)' do
+      subject { delete "/api/v1/topics/#{restricted_topic.id}", headers: auth_headers }
+
+      let!(:restricted_topic) { create(:topic) }
+
+      before do
+        create(:news, topic: restricted_topic)
+      end
+
+      it 'returns conflict status' do
+        subject
+        expect(response).to have_http_status(:conflict)
+      end
+
+      it 'does not destroy the topic' do
+        expect { subject }.not_to change(Topic, :count)
+        expect(restricted_topic.reload).to be_present
+      end
+
+      it 'returns error message' do
+        subject
+        expect(json[:errors]).to be_present
+        expect(json[:errors].first[:message]).to be_present
+      end
+    end
+
+    context 'when record is not found' do
+      subject { delete '/api/v1/topics/999999', headers: auth_headers }
+
+      it 'returns status 404 not found' do
+        subject
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it 'returns error message' do
+        subject
+        expect(json[:errors]).to be_present
+        expect(json[:errors].first[:message]).to be_present
+      end
+    end
+  end
+
+  context 'when authenticated as regular user' do
+    include_context 'with authenticated regular user via JWT'
+
+    context 'when destroying an existing topic' do
+      subject { delete "/api/v1/topics/#{topic.id}", headers: auth_headers }
+
+      it 'returns no content status' do
+        subject
+        expect(response).to have_http_status(:no_content)
+      end
+
+      it 'destroys the topic' do
+        expect { subject }.to change(Topic, :count).by(-1)
+      end
+    end
+
+    context 'when destroying a topic with dependent news (restricted)' do
+      subject { delete "/api/v1/topics/#{restricted_topic.id}", headers: auth_headers }
+
+      let!(:restricted_topic) { create(:topic) }
+
+      before do
+        create(:news, topic: restricted_topic)
+      end
+
+      it 'returns conflict status' do
+        subject
+        expect(response).to have_http_status(:conflict)
+      end
+
+      it 'does not destroy the topic' do
+        expect { subject }.not_to change(Topic, :count)
+      end
+    end
+  end
+
+  context 'when not authenticated' do
+    subject { delete "/api/v1/topics/#{topic.id}", headers: auth_headers }
+
+    let(:auth_headers) { {} }
+
+    it 'returns unauthorized status' do
+      subject
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'does not destroy the topic' do
+      expect { subject }.not_to change(Topic, :count)
+      expect(topic.reload).to be_present
+    end
+
+    it 'returns error message' do
+      subject
+      expect(json[:errors]).to be_present
+      expect(json[:errors].first[:message]).to be_present
+    end
+  end
+
+  context 'when authenticated with invalid token' do
+    subject { delete "/api/v1/topics/#{topic.id}", headers: auth_headers }
+
+    let(:auth_headers) { { 'Authorization' => 'Bearer invalid_token' } }
+
+    it 'returns unauthorized status' do
+      subject
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'does not destroy the topic' do
+      expect { subject }.not_to change(Topic, :count)
+      expect(topic.reload).to be_present
+    end
+
+    it 'returns error message' do
+      subject
+      expect(json[:errors]).to be_present
+      expect(json[:errors].first[:message]).to be_present
+    end
+  end
+end

--- a/spec/requests/api/v1/users/destroy_spec.rb
+++ b/spec/requests/api/v1/users/destroy_spec.rb
@@ -2,7 +2,6 @@
 
 describe 'DELETE api/v1/users/:id' do
   let!(:target_user) { create(:user, :with_name) }
-  let!(:other_user) { create(:user, :with_name) }
 
   context 'when user is admin' do
     include_context 'with authenticated admin user via JWT'


### PR DESCRIPTION
# Resumen
- Agrega endpoints DELETE para topics y mentions.
- Unifica el manejo de errores de eliminación con dependencias mediante 409 Conflict.
- Ajusta asociaciones para usar restrict_with_exception y alinea los controladores con destroy!.
- Cubre escenarios con specs (éxito, dependencias, 404, 401).

# Cambios en la API
- Endpoints nuevos:
   - DELETE /api/v1/topics/:id
   - DELETE /api/v1/mentions/:id
- Respuestas:
   - 204 No Content: eliminado con éxito (body vacío).
   - 409 Conflict: eliminación restringida por asociaciones dependientes.
   - 404 Not Found: recurso inexistente.
   - 401 Unauthorized: token ausente o inválido.
   - 403 Forbidden: si la política lo restringiera (hoy destroy? = true).
   - Estructura de error: {"errors":[{ "message": "<texto i18n>" }]}
- Cambio de comportamiento:
   - Topic#has_many :news pasa de :restrict_with_error a :restrict_with_exception.
   - Mention#has_many :mention_news pasa de :destroy a :restrict_with_exception.
