### PR TITLE
feat: add index filtering for mentions/topics, add pagination limit, add routing not found handler

### DIFF
--- a/app/controllers/api/v1/mentions_controller.rb
+++ b/app/controllers/api/v1/mentions_controller.rb
@@ -6,7 +6,7 @@ module API
       before_action :set_mention, only: %i[update destroy]
 
       def index
-        @mentions = policy_scope(Mention).ordered
+        @mentions = policy_scope(Mention).ordered.filter_by(filtering_params)
       end
 
       def create
@@ -35,6 +35,10 @@ module API
 
       def mention_params
         params.expect(mention: %i[name enabled])
+      end
+
+      def filtering_params
+        params.slice(*Mention.filter_scopes)
       end
     end
   end

--- a/app/controllers/api/v1/topics_controller.rb
+++ b/app/controllers/api/v1/topics_controller.rb
@@ -6,7 +6,7 @@ module API
       before_action :set_topic, only: %i[update destroy]
 
       def index
-        @topics = policy_scope(Topic).ordered
+        @topics = policy_scope(Topic).ordered.filter_by(filtering_params)
       end
 
       def create
@@ -35,6 +35,10 @@ module API
 
       def topic_params
         params.expect(topic: %i[name description enabled])
+      end
+
+      def filtering_params
+        params.slice(*Topic.filter_scopes)
       end
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,14 +5,18 @@ class ApplicationController < ActionController::Base
 
   after_action :verify_authorized,
                except: :index,
-               unless: -> { devise_controller? || active_admin_controller? }
+               unless: -> { devise_controller? || active_admin_controller? || errors_controller? }
   after_action :verify_policy_scoped,
                only: :index,
-               unless: -> { devise_controller? || active_admin_controller? }
+               unless: -> { devise_controller? || active_admin_controller? || errors_controller? }
   # Prevent CSRF attacks by raising an exception.
   protect_from_forgery with: :exception
 
   def active_admin_controller?
     is_a?(ActiveAdmin::BaseController)
+  end
+
+  def errors_controller?
+    is_a?(ErrorsController)
   end
 end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,0 +1,8 @@
+class ErrorsController < ApplicationController
+  # Uncomment this if your API implements authentication
+  # skip_before_action :authenticate_request
+
+  def routing_error
+    head :not_found
+  end
+end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,6 +1,6 @@
-class ErrorsController < ApplicationController
-  # Uncomment this if your API implements authentication
-  # skip_before_action :authenticate_request
+class ErrorsController < ActionController::API
+  # This controller handles not found routes and does not require CSRF protection
+  # as it is intended to return clean 404 responses for API requests
 
   def routing_error
     head :not_found

--- a/app/models/concerns/filterable.rb
+++ b/app/models/concerns/filterable.rb
@@ -1,0 +1,26 @@
+# Credits to: https://ifiwere.me/technology/2020/10/09/clean_index_filtering_rails.html
+module Filterable
+  extend ActiveSupport::Concern
+
+  included do
+    @filter_scopes ||= []
+  end
+
+  class_methods do
+    attr_reader :filter_scopes
+
+    def filter_scope(name, *)
+      scope(name, *)
+      filter_scopes << name
+    end
+
+    def filter_by(filtering_params)
+      results = all
+      filtering_params.each do |filter_scope, filter_value|
+        filter_value = filter_value.reject(&:blank?) if filter_value.is_a?(Array)
+        results = results.public_send(filter_scope, filter_value) if filter_value.present?
+      end
+      results
+    end
+  end
+end

--- a/app/models/mention.rb
+++ b/app/models/mention.rb
@@ -16,10 +16,13 @@
 #
 
 class Mention < ApplicationRecord
+  include Filterable
+
   has_many :mention_news, dependent: :restrict_with_exception
   has_many :news, through: :mention_news
 
   validates :name, presence: true, uniqueness: true
 
   scope :ordered, -> { order(:name) }
+  filter_scope :enabled, ->(enabled) { where(enabled: enabled) }
 end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -17,11 +17,14 @@
 #  index_topics_on_name  (name) UNIQUE
 #
 class Topic < ApplicationRecord
+  include Filterable
+
   has_many :news, dependent: :restrict_with_exception
 
   validates :name, presence: true, uniqueness: true
 
   scope :ordered, -> { order(:name) }
+  filter_scope :enabled, ->(enabled) { where(enabled: enabled) }
 
   def check_crisis!
     update!(crisis: should_be_crisis?)

--- a/app/views/api/v1/shared/_pagination.json.jbuilder
+++ b/app/views/api/v1/shared/_pagination.json.jbuilder
@@ -2,6 +2,7 @@
 
 json.pagination do
   json.page @pagy.page
+  json.limit @pagy.limit
   json.count @pagy.count
   json.pages @pagy.pages
   json.prev @pagy.prev

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -143,7 +143,7 @@
 
 # Limit extra: Allow the client to request a custom limit per page with an optional selector UI
 # See https://ddnexus.github.io/pagy/docs/extras/limit
-# require 'pagy/extras/limit'
+require 'pagy/extras/limit'
 # set to false only if you want to make :limit_extra an opt-in variable
 # Pagy::DEFAULT[:limit_extra] = false    # default true
 # Pagy::DEFAULT[:limit_param] = :limit   # default

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -167,4 +167,8 @@ Rails.application.routes.draw do
 
   mount Rswag::Ui::Engine => '/api-docs'
   mount Rswag::Api::Engine => '/api-docs'
+
+  # This route catches all requests that does not match with any other previous route declared
+  match '*a', to: 'errors#routing_error', via: :all
+  match '/', to: 'errors#routing_error', via: :all
 end

--- a/spec/requests/errors_controller_spec.rb
+++ b/spec/requests/errors_controller_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'ErrorsController' do
+  describe 'GET /non-existent-route' do
+    subject { get '/non-existent-route' }
+
+    it 'returns 404 status' do
+      subject
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'returns empty response body' do
+      subject
+      expect(response.body).to be_empty
+    end
+
+    it 'does not raise CSRF error' do
+      expect { subject }.not_to raise_error
+    end
+  end
+
+  describe 'POST /non-existent-route' do
+    subject { post '/non-existent-route', params: { some: 'data' }, as: :json }
+
+    it 'returns 404 status' do
+      subject
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'returns empty response body' do
+      subject
+      expect(response.body).to be_empty
+    end
+
+    it 'does not raise CSRF error' do
+      expect { subject }.not_to raise_error
+    end
+  end
+
+  describe 'PUT /non-existent-route' do
+    subject { put '/non-existent-route', params: { some: 'data' }, as: :json }
+
+    it 'returns 404 status' do
+      subject
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'returns empty response body' do
+      subject
+      expect(response.body).to be_empty
+    end
+
+    it 'does not raise CSRF error' do
+      expect { subject }.not_to raise_error
+    end
+  end
+
+  describe 'DELETE /non-existent-route' do
+    subject { delete '/non-existent-route' }
+
+    it 'returns 404 status' do
+      subject
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'returns empty response body' do
+      subject
+      expect(response.body).to be_empty
+    end
+
+    it 'does not raise CSRF error' do
+      expect { subject }.not_to raise_error
+    end
+  end
+
+  describe 'PATCH /non-existent-route' do
+    subject { patch '/non-existent-route', params: { some: 'data' }, as: :json }
+
+    it 'returns 404 status' do
+      subject
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'returns empty response body' do
+      subject
+      expect(response.body).to be_empty
+    end
+
+    it 'does not raise CSRF error' do
+      expect { subject }.not_to raise_error
+    end
+  end
+
+  describe 'GET /' do
+    subject { get '/' }
+
+    it 'returns 404 status for root path' do
+      subject
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'returns empty response body for root path' do
+      subject
+      expect(response.body).to be_empty
+    end
+
+    it 'does not raise CSRF error' do
+      expect { subject }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
# Resumen
- Añade filtrado en index para Mentions y Topics usando un concern genérico.
- Expone limit en la paginación y habilita pagy/extras/limit.
- Introduce un ErrorsController y rutas catch‑all para responder 404 limpios.
- Cubre con specs de request los nuevos filtros y casos inválidos.

# Motivación
- Permitir que consumidores del API filtren resultados sin lógica ad‑hoc por
controlador.
- Estandarizar y exponer el limit de paginación solicitado por el cliente.
- Asegurar respuestas controladas para rutas inexistentes, evitando ruido en
logs y errores de autorización.

# Cambios Clave
- Controladores:
    - MentionsController#index y TopicsController#index: aplican
filter_by(filtering_params).
    - Nuevo método filtering_params: usa params.slice(*Model.filter_scopes) para
ignorar parámetros no válidos.
- Modelos:
    - Nuevo concern Filterable: define filter_scope y filter_by reutilizables.
    - Mention y Topic: incluyen Filterable y añaden filter_scope :enabled.
- Paginación:
    - Habilita pagy/extras/limit y agrega json.limit @pagy.limit en
_pagination.json.jbuilder.
- Errores/Rutas:
    - Nuevo ErrorsController#routing_error que responde 404.
    - ApplicationController: excluye ErrorsController de verify_authorized y
verify_policy_scoped.
    - Rutas catch‑all para retornar 404 en paths no definidos (incluye /).
- Tests:
    - Specs de index para mentions y topics validando:
    - Filtrado por `enabled=true/false`.
    - Ignora parámetros inválidos.
    - Ajuste de fixtures para cubrir `enabled: false`.

# API Uso
- Filtrado:
    - GET /api/v1/mentions?enabled=true
    - GET /api/v1/topics?enabled=false
- Paginación:
    - GET ...?page=2&limit=50
    - Respuesta incluye pagination.limit.

