### PR TITLE
feat: add update news action

### DIFF
--- a/app/controllers/api/v1/news_controller.rb
+++ b/app/controllers/api/v1/news_controller.rb
@@ -50,7 +50,6 @@ module API
           :section,
           :author,
           :interviewee,
-          :plain_text,
           :audience_size,
           :quotation,
           :valuation,

--- a/app/policies/news_policy.rb
+++ b/app/policies/news_policy.rb
@@ -4,4 +4,6 @@ class NewsPolicy < ApplicationPolicy
   def index? = true
 
   def batch_process? = true
+
+  def update? = true
 end

--- a/app/views/api/v1/news/show.json.jbuilder
+++ b/app/views/api/v1/news/show.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! 'news_item', news: @news

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -156,7 +156,7 @@ Rails.application.routes.draw do
         patch :change_password, on: :member
       end
       resources :topics, only: %i[index create update destroy]
-      resources :news, only: %i[index] do
+      resources :news, only: %i[index update] do
         post :batch_process, on: :collection
       end
       resources :mentions, only: %i[index create update destroy]

--- a/spec/requests/api/v1/news/update_spec.rb
+++ b/spec/requests/api/v1/news/update_spec.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+describe 'PUT api/v1/news/:id' do
+  let(:news) { create(:news) }
+
+  subject(:perform_request) do
+    put api_v1_news_path(news), params: params, headers: auth_headers, as: :json
+  end
+
+  context 'when authenticated as admin user' do
+    include_context 'with authenticated admin user via JWT'
+
+    let(:new_topic) { create(:topic, name: 'Updated Topic') }
+    let(:new_mentions) { create_list(:mention, 2) }
+    let(:params) do
+      {
+        news: {
+          title: 'Updated title',
+          publication_type: 'opinion',
+          valuation: 'negative',
+          political_factor: 'nacional',
+          topic_id: new_topic.id,
+          mention_ids: new_mentions.map(&:id)
+        }
+      }
+    end
+
+    it 'returns a successful response' do
+      perform_request
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'updates the news attributes', :aggregate_failures do
+      perform_request
+      news.reload
+      expect(news.title).to eq('Updated title')
+      expect(news.valuation).to eq('negative')
+      expect(news.political_factor).to eq('nacional')
+      expect(news.topic_id).to eq(new_topic.id)
+      expect(news.mentions.pluck(:id)).to match_array(new_mentions.map(&:id))
+    end
+
+    it 'assigns the current user as reviewer' do
+      perform_request
+      expect(news.reload.reviewer_id).to eq(admin_user.id)
+    end
+
+    it 'returns the updated news payload', :aggregate_failures do
+      perform_request
+      expect(json[:id]).to eq(news.id)
+      expect(json[:title]).to eq('Updated title')
+      expect(json[:reviewer][:id]).to eq(admin_user.id)
+      expect(json[:topic][:id]).to eq(new_topic.id)
+      expect(json[:mentions].map { |mention| mention[:id] }).to match_array(new_mentions.map(&:id))
+    end
+  end
+
+  context 'when authenticated as regular user' do
+    include_context 'with authenticated regular user via JWT'
+
+    let(:new_topic) { create(:topic, name: 'Regular Reviewer Topic') }
+    let(:params) do
+      {
+        news: {
+          valuation: 'positive',
+          topic_id: new_topic.id
+        }
+      }
+    end
+
+    it 'updates the news and assigns the reviewer' do
+      perform_request
+      news.reload
+      expect(news.valuation).to eq('positive')
+      expect(news.topic_id).to eq(new_topic.id)
+      expect(news.reviewer_id).to eq(regular_user.id)
+    end
+  end
+
+  context 'when the news does not exist' do
+    include_context 'with authenticated admin user via JWT'
+
+    let(:params) do
+      {
+        news: {
+          valuation: 'neutral'
+        }
+      }
+    end
+
+    subject(:perform_request) do
+      put api_v1_news_path(-1), params: params, headers: auth_headers, as: :json
+    end
+
+    it 'returns not found status' do
+      perform_request
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  context 'when news params are missing' do
+    include_context 'with authenticated admin user via JWT'
+
+    let(:params) { {} }
+
+    it 'returns bad request status' do
+      perform_request
+      expect(response).to have_http_status(:bad_request)
+    end
+  end
+
+  context 'when not authenticated' do
+    let(:auth_headers) { {} }
+    let(:params) do
+      {
+        news: {
+          valuation: 'neutral'
+        }
+      }
+    end
+
+    it 'returns unauthorized status' do
+      perform_request
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  context 'when authenticated with invalid token' do
+    let(:auth_headers) { { 'Authorization' => 'Bearer invalid_token' } }
+    let(:params) do
+      {
+        news: {
+          valuation: 'positive'
+        }
+      }
+    end
+
+    it 'returns unauthorized status' do
+      perform_request
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+end


### PR DESCRIPTION
Resumen

- Nuevo endpoint de actualización de noticias: PUT/PATCH /api/v1/news/:id que permita hacer revisiones manuales.
- Asigna automáticamente al usuario autenticado como reviewer al editar. 
- Se decide tener trazabilidad simple, guardar solo quien fue el último revisor. La hora de actualización ya se guarda en el updated_at.
- Renderiza la noticia actualizada con el mismo payload de show (parcial news_item).

Campos permitidos

- title, publication_type, date, support, media, section, author, interviewee, audience_size, quotation, valuation,
political_factor, topic_id, mention_ids: [].

Errores y estados

- 404 si el id no existe.
- 400 si faltan params (news).
- 401 si no hay auth o token inválido.

Permisos

- Habilitado para cualquier autenticado.

Ejemplo de request

- PUT /api/v1/news/:id con body:
    - {"news":{"valuation":"positive","topic_id":123,"mention_ids":[1,2]}}