### PR TITLE
feat: add clipping metrics persistence and validation rules

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -709,6 +709,14 @@ Crea un nuevo clipping en el sistema con un conjunto de noticias y fechas espec�
                         { "key": "Digital", "count": 1, "percentage": 33.33 }
                     ]
                 },
+                "mention_stats": {
+                    "total": 4,
+                    "items": [
+                        { "mention_id": 1, "name": "Ministerio de Transporte", "count": 2, "percentage": 50.0 },
+                        { "mention_id": 2, "name": "Jorge Macri", "count": 1, "percentage": 25.0 },
+                        { "mention_id": 3, "name": "Gabriela Ricardes", "count": 1, "percentage": 25.0 }
+                    ]
+                },
                 "audience": {
                     "total": 3000,
                     "average": 1500.0,
@@ -1569,6 +1577,7 @@ Recibe un conjunto de noticias **ya clasificadas** por el backend y genera un in
     + total: 3 (number) - Total de noticias con valoración conocida
 + media_stats (MetricCollection) - Estadísticas agrupadas por medio
 + support_stats (MetricCollection) - Estadísticas agrupadas por soporte
++ mention_stats (MentionStatsCollection) - Estadísticas de menciones asociadas a las noticias del clipping
 + audience (MetricAggregate, nullable) - Agregados de audiencia cuando existen datos
 + quotation (MetricAggregate, nullable) - Agregados de cotización cuando existen datos
 + crisis: false (boolean) - Indica si el tema asociado está marcado como crisis
@@ -1585,6 +1594,16 @@ Recibe un conjunto de noticias **ya clasificadas** por el backend y genera un in
 + key: "Clarín" (string) - Valor agrupado
 + count: 2 (number) - Cantidad de noticias con ese valor
 + percentage: 66.67 (number) - Porcentaje respecto del total del agrupamiento
+
+### MentionStatsCollection (object)
++ total: 4 (number) - Total de menciones contabilizadas en las noticias del clipping
++ items: (array[MentionStatsItem]) - Detalle por mención
+
+### MentionStatsItem (object)
++ mention_id: 1 (number) - ID único de la mención
++ name: "Ministerio de Transporte" (string) - Nombre de la mención
++ count: 2 (number) - Cantidad de veces que aparece la mención en las noticias del clipping
++ percentage: 50.0 (number) - Porcentaje respecto del total de menciones
 
 ### MetricAggregate (object)
 + total: 3000 (number) - Suma total del campo

--- a/apiary.apib
+++ b/apiary.apib
@@ -659,6 +659,8 @@ Obtiene una lista paginada de todos los clippings en el sistema, ordenados por f
 
 Crea un nuevo clipping en el sistema con un conjunto de noticias y fechas específicas.
 
+> Es obligatorio incluir al menos un ID de noticia en `news_ids`.
+
 + Request (application/json)
     + Headers
         Authorization: Bearer {jwt_token}

--- a/apiary.apib
+++ b/apiary.apib
@@ -634,7 +634,6 @@ Obtiene una lista paginada de todos los clippings en el sistema, ordenados por f
                     "end_date": "2025-01-07",
                     "topic_id": 1,
                     "news_ids": [1, 2, 3],
-                    "news_count": 3,
                     "created_at": "2025-01-09T10:30:00Z",
                     "updated_at": "2025-01-09T10:30:00Z",
                     "creator": {
@@ -684,7 +683,42 @@ Crea un nuevo clipping en el sistema con un conjunto de noticias y fechas espec�
             "end_date": "2025-01-07",
             "topic_id": 1,
             "news_ids": [1, 2, 3],
-            "news_count": 3,
+            "metrics": {
+                "generated_at": "2025-01-09T10:30:00Z",
+                "date_range": { "from": "2025-01-01", "to": "2025-01-07" },
+                "news_count": 3,
+                "valuation": {
+                    "positive": { "count": 1, "percentage": 33.33 },
+                    "neutral": { "count": 1, "percentage": 33.33 },
+                    "negative": { "count": 1, "percentage": 33.33 },
+                    "total": 3
+                },
+                "media_stats": {
+                    "total": 3,
+                    "items": [
+                        { "key": "Clarín", "count": 2, "percentage": 66.67 },
+                        { "key": "La Nación", "count": 1, "percentage": 33.33 }
+                    ]
+                },
+                "support_stats": {
+                    "total": 3,
+                    "items": [
+                        { "key": "Print", "count": 2, "percentage": 66.67 },
+                        { "key": "Digital", "count": 1, "percentage": 33.33 }
+                    ]
+                },
+                "audience": {
+                    "total": 3000,
+                    "average": 1500.0,
+                    "max": { "news_id": 2, "value": 2000 }
+                },
+                "quotation": {
+                    "total": 411.5,
+                    "average": 137.17,
+                    "max": { "news_id": 3, "value": 210.75 }
+                },
+                "crisis": false
+            },
             "created_at": "2025-01-09T10:30:00Z",
             "updated_at": "2025-01-09T10:30:00Z",
             "creator": {
@@ -1515,10 +1549,49 @@ Recibe un conjunto de noticias **ya clasificadas** por el backend y genera un in
 + end_date: "2025-01-07" (string) - Fecha de fin del período (ISO 8601)
 + topic_id: 1 (number) - ID del tema asociado
 + news_ids: [1, 2, 3] (array[number]) - Array de IDs de noticias incluidas
-+ news_count: 3 (number) - Cantidad de noticias en el clipping
 + created_at: "2025-01-09T10:30:00Z" (string) - Fecha de creación (ISO 8601)
 + updated_at: "2025-01-09T10:30:00Z" (string) - Fecha de última actualización (ISO 8601)
 + creator (EntityRef) - Usuario que creó el clipping
++ metrics (ClippingMetrics, optional) - Métricas agregadas del clipping. Disponible en los endpoints de detalle, creación y actualización.
+
+### ClippingMetrics (object)
++ generated_at: "2025-01-09T10:30:00Z" (string) - Momento del último cálculo (ISO 8601)
++ date_range (object) - Rango temporal de las noticias incluidas
+    + from: "2025-01-01" (string, nullable) - Fecha mínima encontrada
+    + to: "2025-01-07" (string, nullable) - Fecha máxima encontrada
++ news_count: 3 (number) - Cantidad total de noticias consideradas
++ valuation (object) - Distribución de noticias por valoración
+    + positive (MetricBreakdown)
+    + neutral (MetricBreakdown)
+    + negative (MetricBreakdown)
+    + total: 3 (number) - Total de noticias con valoración conocida
++ media_stats (MetricCollection) - Estadísticas agrupadas por medio
++ support_stats (MetricCollection) - Estadísticas agrupadas por soporte
++ audience (MetricAggregate, nullable) - Agregados de audiencia cuando existen datos
++ quotation (MetricAggregate, nullable) - Agregados de cotización cuando existen datos
++ crisis: false (boolean) - Indica si el tema asociado está marcado como crisis
+
+### MetricBreakdown (object)
++ count: 1 (number) - Cantidad de noticias en la categoría
++ percentage: 33.33 (number) - Porcentaje respecto del total
+
+### MetricCollection (object)
++ total: 3 (number) - Total de elementos considerados
++ items: (array[MetricCollectionItem]) - Detalle por clave
+
+### MetricCollectionItem (object)
++ key: "Clarín" (string) - Valor agrupado
++ count: 2 (number) - Cantidad de noticias con ese valor
++ percentage: 66.67 (number) - Porcentaje respecto del total del agrupamiento
+
+### MetricAggregate (object)
++ total: 3000 (number) - Suma total del campo
++ average: 1500.0 (number) - Promedio del campo
++ max: (MetricAggregateMax, nullable) - Valor máximo encontrado
+
+### MetricAggregateMax (object)
++ news_id: 2 (number) - ID de la noticia que posee el máximo
++ value: 2000 (number) - Valor máximo registrado
 
 ### Pagination (object)
 + page: 1 (number) - Página actual

--- a/app/controllers/api/v1/clippings_controller.rb
+++ b/app/controllers/api/v1/clippings_controller.rb
@@ -6,7 +6,10 @@ module API
       before_action :set_clipping, only: %i[show update destroy]
 
       def index
-        scoped = policy_scope(Clipping).filter_by(filtering_params).ordered
+        scoped = policy_scope(Clipping)
+                 .filter_by(filtering_params)
+                 .includes(:news)
+                 .ordered
         @pagy, @clippings = pagy(scoped)
       end
 
@@ -35,7 +38,7 @@ module API
       private
 
       def set_clipping
-        @clipping = Clipping.find(params[:id])
+        @clipping = Clipping.includes(:news).find(params[:id])
       end
 
       def clipping_params

--- a/app/models/clipping.rb
+++ b/app/models/clipping.rb
@@ -40,6 +40,7 @@ class Clipping < ApplicationRecord
 
   validates :name, :start_date, :end_date, presence: true
   validate :end_date_not_before_start_date
+  validate :must_have_at_least_one_news
 
   scope :ordered, -> { order(created_at: :desc) }
   filter_scope :topic_id, ->(id) { where(topic_id: id) }
@@ -67,5 +68,11 @@ class Clipping < ApplicationRecord
     return unless end_date < start_date
 
     errors.add(:end_date, :before_start_date, message: 'must be on or after start date')
+  end
+
+  def must_have_at_least_one_news
+    return if news.any?
+
+    errors.add(:news_ids, 'must include at least one news')
   end
 end

--- a/app/models/clipping.rb
+++ b/app/models/clipping.rb
@@ -34,6 +34,7 @@ class Clipping < ApplicationRecord
   belongs_to :topic
 
   before_validation :normalize_news_ids
+  before_save :refresh_metrics, if: :should_refresh_metrics?
 
   attr_reader :invalid_news_ids
 
@@ -63,6 +64,14 @@ class Clipping < ApplicationRecord
   end
 
   private
+
+  def should_refresh_metrics?
+    new_record? || will_save_change_to_news_ids?
+  end
+
+  def refresh_metrics
+    self.metrics = Clippings::MetricsBuilder.call(self)
+  end
 
   def normalize_news_ids
     normalized = []

--- a/app/models/clipping.rb
+++ b/app/models/clipping.rb
@@ -78,18 +78,18 @@ class Clipping < ApplicationRecord
     return if start_date.blank? || end_date.blank?
     return unless end_date < start_date
 
-    errors.add(:end_date, :before_start_date, message: 'must be on or after start date')
+    errors.add(:end_date, :before_start_date)
   end
 
   def must_have_at_least_one_news
     return if news_ids.present? && news_ids.any?
 
-    errors.add(:news_ids, 'must include at least one news')
+    errors.add(:news_ids, :blank)
   end
 
   def topic_must_be_enabled
     return if topic.blank? || topic.enabled?
 
-    errors.add(:topic, 'must be enabled')
+    errors.add(:topic, :disabled)
   end
 end

--- a/app/models/clipping.rb
+++ b/app/models/clipping.rb
@@ -6,8 +6,8 @@
 #
 #  id         :bigint           not null, primary key
 #  end_date   :date             not null
+#  metrics    :jsonb            not null
 #  name       :string           not null
-#  news_ids   :jsonb            not null
 #  start_date :date             not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -18,7 +18,6 @@
 #
 #  index_clippings_on_creator_id  (creator_id)
 #  index_clippings_on_end_date    (end_date)
-#  index_clippings_on_news_ids    (news_ids) USING gin
 #  index_clippings_on_start_date  (start_date)
 #  index_clippings_on_topic_id    (topic_id)
 #
@@ -33,56 +32,33 @@ class Clipping < ApplicationRecord
   belongs_to :creator, class_name: 'User'
   belongs_to :topic
 
-  before_validation :normalize_news_ids
-  before_save :refresh_metrics, if: :should_refresh_metrics?
+  has_many :clipping_news, dependent: :destroy
+  has_many :news, through: :clipping_news
 
-  attr_reader :invalid_news_ids
+  before_save :assign_metrics
 
   validates :name, :start_date, :end_date, presence: true
   validate :end_date_not_before_start_date
-  validate :news_ids_must_be_positive_integers
-  validate :news_ids_must_exist
 
   scope :ordered, -> { order(created_at: :desc) }
   filter_scope :topic_id, ->(id) { where(topic_id: id) }
   filter_scope :news_ids, lambda { |ids|
-    # Use @> operator with OR to leverage GIN index on JSONB array
-    # Each condition checks if news_ids contains at least one specific ID
-    return all if ids.blank?
+    sanitized_ids = Array.wrap(ids).map(&:to_i).select(&:positive?)
+    return all if sanitized_ids.empty?
 
-    sanitized_ids = ids.map(&:to_i)
-    conditions = sanitized_ids.map { "#{table_name}.news_ids @> ?" }
-    values = sanitized_ids.map { |id| [id].to_json }
-
-    where(conditions.join(' OR '), *values)
+    joins(:clipping_news).where(clipping_news: { news_id: sanitized_ids }).distinct
   }
   filter_scope :start_date, ->(date) { where(arel_table[:start_date].gteq(date)) }
   filter_scope :end_date, ->(date) { where(arel_table[:end_date].lteq(date)) }
 
-  def news_count
-    news_ids.size
+  def refresh_metrics!
+    update!(metrics: Clippings::MetricsBuilder.call(self))
   end
 
   private
 
-  def should_refresh_metrics?
-    new_record? || will_save_change_to_news_ids?
-  end
-
-  def refresh_metrics
+  def assign_metrics
     self.metrics = Clippings::MetricsBuilder.call(self)
-  end
-
-  def normalize_news_ids
-    normalized = []
-    @invalid_news_ids = []
-
-    Array.wrap(news_ids).each do |value|
-      int = cast_positive_integer(value)
-      int ? normalized << int : @invalid_news_ids << value
-    end
-
-    self.news_ids = normalized
   end
 
   def end_date_not_before_start_date
@@ -90,28 +66,5 @@ class Clipping < ApplicationRecord
     return unless end_date < start_date
 
     errors.add(:end_date, :before_start_date, message: 'must be on or after start date')
-  end
-
-  def news_ids_must_be_positive_integers
-    return if invalid_news_ids.blank?
-
-    errors.add(:news_ids, 'must contain positive integer IDs')
-  end
-
-  def news_ids_must_exist
-    return if news_ids.blank?
-
-    existing_ids = News.where(id: news_ids).pluck(:id)
-    missing_ids = news_ids - existing_ids
-    return if missing_ids.empty?
-
-    errors.add(:news_ids, 'must reference existing news')
-  end
-
-  def cast_positive_integer(value)
-    int = Integer(value, exception: false)
-    int&.positive? ? int : nil
-  rescue TypeError
-    nil
   end
 end

--- a/app/models/clipping.rb
+++ b/app/models/clipping.rb
@@ -18,6 +18,7 @@
 #
 #  index_clippings_on_creator_id  (creator_id)
 #  index_clippings_on_end_date    (end_date)
+#  index_clippings_on_metrics     (metrics) USING gin
 #  index_clippings_on_start_date  (start_date)
 #  index_clippings_on_topic_id    (topic_id)
 #

--- a/app/models/clipping_news.rb
+++ b/app/models/clipping_news.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class ClippingNews < ApplicationRecord
+  belongs_to :clipping
+  belongs_to :news
+
+  validates :news_id, uniqueness: { scope: :clipping_id }
+
+  after_commit :refresh_clipping_metrics, on: %i[create destroy]
+
+  private
+
+  def refresh_clipping_metrics
+    return if clipping.destroyed?
+
+    clipping.refresh_metrics!
+  end
+end

--- a/app/models/clipping_news.rb
+++ b/app/models/clipping_news.rb
@@ -1,5 +1,26 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: clipping_news
+#
+#  id          :bigint           not null, primary key
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  clipping_id :bigint           not null
+#  news_id     :bigint           not null
+#
+# Indexes
+#
+#  index_clipping_news_on_clipping_id              (clipping_id)
+#  index_clipping_news_on_clipping_id_and_news_id  (clipping_id,news_id) UNIQUE
+#  index_clipping_news_on_news_id                  (news_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (clipping_id => clippings.id)
+#  fk_rails_...  (news_id => news.id)
+#
 class ClippingNews < ApplicationRecord
   belongs_to :clipping
   belongs_to :news

--- a/app/models/news.rb
+++ b/app/models/news.rb
@@ -50,10 +50,14 @@ class News < ApplicationRecord
 
   has_many :mention_news, dependent: :destroy
   has_many :mentions, through: :mention_news
+  has_many :clipping_news, dependent: :destroy
+  has_many :clippings, through: :clipping_news
 
   validates :title, :date, :support, :media, :link, presence: true
 
   enum :valuation, { positive: 'positive', neutral: 'neutral', negative: 'negative' }, prefix: true
+
+  METRIC_ATTRIBUTES = %i[valuation media support date audience_size quotation].freeze
 
   scope :ordered, -> { order(created_at: :desc) }
   filter_scope :topic_id, ->(id) { where(topic_id: id) }
@@ -64,8 +68,11 @@ class News < ApplicationRecord
   filter_scope :valuation, ->(valuation) { where(valuation: valuation) }
 
   after_create :check_topic_crisis
+  before_update :prevent_topic_change_when_clipped, if: :will_save_change_to_topic_id?
+  before_update :ensure_date_within_clipping_bounds, if: :will_save_change_to_date?
   after_update :check_topic_crisis, if: -> { saved_change_to_valuation? || saved_change_to_topic_id? }
   after_destroy :check_topic_crisis
+  after_commit :refresh_related_clippings_metrics, on: :update, if: :metrics_affecting_previous_changes?
 
   def requires_manual_review?
     manual_review_fields.include?('REVISAR MANUAL') || required_fields.any?(&:nil?)
@@ -90,5 +97,33 @@ class News < ApplicationRecord
       Topic.find(topic_id_before_last_save).check_crisis!
     end
     topic&.check_crisis!
+  end
+
+  def refresh_related_clippings_metrics
+    clippings.find_each(&:refresh_metrics!)
+  end
+
+  def metrics_affecting_previous_changes?
+    changed_keys = previous_changes.keys.map(&:to_sym)
+    (changed_keys & METRIC_ATTRIBUTES).any?
+  end
+
+  def prevent_topic_change_when_clipped
+    previous_topic_id = topic_id_in_database
+    return if previous_topic_id.blank?
+
+    clippings_scope = clippings.where(topic_id: previous_topic_id)
+    return unless clippings_scope.exists?
+
+    errors.add(:topic_id, 'cannot be changed while the news belongs to clippings for the current topic')
+    throw :abort
+  end
+
+  def ensure_date_within_clipping_bounds
+    violating = clippings.where.not('clippings.start_date <= ? AND clippings.end_date >= ?', date, date)
+    return unless violating.exists?
+
+    errors.add(:date, 'cannot move outside the date range of linked clippings')
+    throw :abort
   end
 end

--- a/app/services/clippings/metrics_builder.rb
+++ b/app/services/clippings/metrics_builder.rb
@@ -19,6 +19,7 @@ module Clippings
         valuation: valuation_stats,
         media_stats: collection_stats(:media),
         support_stats: collection_stats(:support),
+        mention_stats: mention_stats,
         audience: numeric_stats(:audience_size),
         quotation: numeric_stats(:quotation),
         crisis: crisis?
@@ -61,6 +62,29 @@ module Clippings
       items = counts.sort_by { |key, count| [-count, key.to_s.downcase] }.map do |key, count|
         {
           key: key,
+          count: count,
+          percentage: percentage(count, total)
+        }
+      end
+
+      {
+        total: total,
+        items: items
+      }
+    end
+
+    def mention_stats
+      counts = MentionNews
+               .joins(:mention)
+               .where(news_id: news_scope.select(:id))
+               .group('mentions.id', 'mentions.name')
+               .count
+      total = counts.values.sum
+
+      items = counts.sort_by { |(_id, name), count| [-count, name.downcase] }.map do |(id, name), count|
+        {
+          mention_id: id,
+          name: name,
           count: count,
           percentage: percentage(count, total)
         }

--- a/app/services/clippings/metrics_builder.rb
+++ b/app/services/clippings/metrics_builder.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+module Clippings
+  class MetricsBuilder
+    def self.call(clipping)
+      new(clipping).call
+    end
+
+    def initialize(clipping)
+      @clipping = clipping
+      @news_scope = News.where(id: clipping.news_ids)
+    end
+
+    def call
+      {
+        generated_at: Time.current.iso8601,
+        date_range: date_range,
+        news_count: news_count,
+        valuation: valuation_stats,
+        media_stats: collection_stats(:media),
+        support_stats: collection_stats(:support),
+        audience: numeric_stats(:audience_size),
+        quotation: numeric_stats(:quotation),
+        crisis: crisis_flag
+      }
+    end
+
+    private
+
+    attr_reader :clipping, :news_scope
+
+    def news_count
+      @news_count ||= news_scope.count
+    end
+
+    def date_range
+      return { from: nil, to: nil } if news_count.zero?
+
+      {
+        from: news_scope.minimum(:date),
+        to: news_scope.maximum(:date)
+      }
+    end
+
+    def valuation_stats
+      counts = news_scope.group(:valuation).count.transform_keys { |key| key&.to_s }
+      total = news_count
+
+      {
+        positive: breakdown_for(counts['positive'], total),
+        neutral: breakdown_for(counts['neutral'], total),
+        negative: breakdown_for(counts['negative'], total),
+        total: total
+      }
+    end
+
+    def collection_stats(field)
+      counts = news_scope.where.not(field => [nil, '']).group(field).count
+      total = counts.values.sum
+
+      items = counts.sort_by { |key, count| [-count, key.to_s.downcase] }.map do |key, count|
+        {
+          key: key,
+          count: count,
+          percentage: percentage(count, total)
+        }
+      end
+
+      {
+        total: total,
+        items: items
+      }
+    end
+
+    def numeric_stats(field)
+      values = news_scope.where.not(field => nil).pluck(:id, field)
+      return { total: nil, average: nil, max: nil } if values.empty?
+
+      numeric_values = values.map { |id, value| [id, cast_numeric(field, value)] }
+      total_value = numeric_values.sum { |_id, value| value }
+      count = numeric_values.size
+      max_id, max_value = numeric_values.max_by { |_id, value| value }
+
+      {
+        total: total_value,
+        average: (total_value.to_f / count).round(2),
+        max: { news_id: max_id, value: max_value }
+      }
+    end
+
+    def breakdown_for(count, total)
+      count = count.to_i
+
+      {
+        count: count,
+        percentage: percentage(count, total)
+      }
+    end
+
+    def percentage(count, total)
+      return 0.0 if total.zero?
+
+      ((count.to_f / total) * 100).round(2)
+    end
+
+    def cast_numeric(field, value)
+      field == :audience_size ? value.to_i : value.to_f
+    end
+
+    def crisis_flag
+      clipping.topic&.crisis? || false
+    end
+  end
+end

--- a/app/services/clippings/metrics_builder.rb
+++ b/app/services/clippings/metrics_builder.rb
@@ -20,9 +20,9 @@ module Clippings
         media_stats: collection_stats(:media),
         support_stats: collection_stats(:support),
         mention_stats: mention_stats,
-        audience: numeric_stats(:audience_size),
-        quotation: numeric_stats(:quotation),
-        crisis: crisis?
+        audience: numeric_field_stats(:audience_size),
+        quotation: numeric_field_stats(:quotation),
+        crisis: clipping.topic&.crisis? || false
       }
     end
 
@@ -37,21 +37,18 @@ module Clippings
     def date_range
       return { from: nil, to: nil } if news_count.zero?
 
-      {
-        from: news_scope.minimum(:date),
-        to: news_scope.maximum(:date)
-      }
+      dates = news_scope.pick(Arel.sql('MIN(date), MAX(date)'))
+      { from: dates[0], to: dates[1] }
     end
 
     def valuation_stats
-      counts = news_scope.group(:valuation).count.transform_keys { |key| key&.to_s }
-      total = news_count
+      counts = news_scope.group(:valuation).count.transform_keys(&:to_s)
 
       {
-        positive: breakdown_for(counts['positive'], total),
-        neutral: breakdown_for(counts['neutral'], total),
-        negative: breakdown_for(counts['negative'], total),
-        total: total
+        positive: valuation_breakdown(counts['positive']),
+        neutral: valuation_breakdown(counts['neutral']),
+        negative: valuation_breakdown(counts['negative']),
+        total: news_count
       }
     end
 
@@ -59,17 +56,11 @@ module Clippings
       counts = news_scope.where.not(field => [nil, '']).group(field).count
       total = counts.values.sum
 
-      items = counts.sort_by { |key, count| [-count, key.to_s.downcase] }.map do |key, count|
-        {
-          key: key,
-          count: count,
-          percentage: percentage(count, total)
-        }
-      end
-
       {
         total: total,
-        items: items
+        items: counts
+          .sort_by { |key, count| [-count, key.to_s.downcase] }
+          .map { |key, count| build_collection_item(key, count, total) }
       }
     end
 
@@ -79,84 +70,62 @@ module Clippings
                .where(news_id: news_scope.select(:id))
                .group('mentions.id', 'mentions.name')
                .count
+
       total = counts.values.sum
 
-      items = counts.sort_by { |(_id, name), count| [-count, name.downcase] }.map do |(id, name), count|
-        {
-          mention_id: id,
-          name: name,
-          count: count,
-          percentage: percentage(count, total)
-        }
-      end
-
       {
         total: total,
-        items: items
+        items: counts
+          .sort_by { |(_, name), count| [-count, name.downcase] }
+          .map { |(id, name), count| build_mention_item(id, name, count, total) }
       }
     end
 
-    def numeric_stats(field)
-      numeric_values = values_for(field)
-      return empty_numeric_stats if numeric_values.empty?
+    def numeric_field_stats(field)
+      values = news_scope.where.not(field => nil).pluck(:id, field)
+      return { total: nil, average: nil, max: nil } if values.empty?
 
-      total = sum_values(numeric_values)
-      count = numeric_values.size
-      max_pair = numeric_values.max_by(&:last)
+      typed_values = values.map { |id, val| [id, cast_to_numeric(field, val)] }
+      total = typed_values.sum(&:last)
+      max_news_id, max_value = typed_values.max_by(&:last)
 
       {
         total: total,
-        average: average_for(total, count),
-        max: build_max_hash(max_pair)
+        average: (total.to_f / typed_values.size).round(2),
+        max: { news_id: max_news_id, value: max_value }
       }
     end
 
-    def breakdown_for(count, total)
+    def valuation_breakdown(count)
       count = count.to_i
+      { count: count, percentage: calculate_percentage(count, news_count) }
+    end
 
+    def build_collection_item(key, count, total)
       {
+        key: key,
         count: count,
-        percentage: percentage(count, total)
+        percentage: calculate_percentage(count, total)
       }
     end
 
-    def percentage(count, total)
+    def build_mention_item(mention_id, name, count, total)
+      {
+        mention_id: mention_id,
+        name: name,
+        count: count,
+        percentage: calculate_percentage(count, total)
+      }
+    end
+
+    def calculate_percentage(count, total)
       return 0.0 if total.zero?
 
       ((count.to_f / total) * 100).round(2)
     end
 
-    def cast_numeric(field, value)
+    def cast_to_numeric(field, value)
       field == :audience_size ? value.to_i : value.to_f
-    end
-
-    def crisis?
-      clipping.topic&.crisis? || false
-    end
-
-    def values_for(field)
-      news_scope.where.not(field => nil).pluck(:id, field).map do |id, value|
-        [id, cast_numeric(field, value)]
-      end
-    end
-
-    def empty_numeric_stats
-      { total: nil, average: nil, max: nil }
-    end
-
-    def sum_values(numeric_values)
-      numeric_values.sum { |_id, value| value }
-    end
-
-    def average_for(total, count)
-      (total.to_f / count).round(2)
-    end
-
-    def build_max_hash(max_pair)
-      return if max_pair.blank?
-
-      news_id, value = max_pair
-      { news_id: news_id, value: value }
     end
   end
 end

--- a/app/validators/clipping_constraints_validator.rb
+++ b/app/validators/clipping_constraints_validator.rb
@@ -17,10 +17,7 @@ class ClippingConstraintsValidator < ActiveModel::Validator
     blocking_clippings = record.clippings.where(topic_id: previous_topic_id)
     return unless blocking_clippings.exists?
 
-    record.errors.add(
-      :topic_id,
-      'cannot be changed while the news belongs to clippings for the current topic'
-    )
+    record.errors.add(:topic_id, :clipping_restriction)
   end
 
   def validate_date_change(record)
@@ -28,9 +25,6 @@ class ClippingConstraintsValidator < ActiveModel::Validator
     blocking_clippings = record.clippings.where('start_date > ? OR end_date < ?', new_date, new_date)
     return unless blocking_clippings.exists?
 
-    record.errors.add(
-      :date,
-      'cannot move outside the date range of linked clippings'
-    )
+    record.errors.add(:date, :clipping_bounds)
   end
 end

--- a/app/validators/clipping_constraints_validator.rb
+++ b/app/validators/clipping_constraints_validator.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class ClippingConstraintsValidator < ActiveModel::Validator
+  def validate(record)
+    return unless record.persisted?
+
+    validate_topic_change(record) if record.will_save_change_to_topic_id?
+    validate_date_change(record) if record.will_save_change_to_date?
+  end
+
+  private
+
+  def validate_topic_change(record)
+    previous_topic_id = record.topic_id_in_database
+    return if previous_topic_id.blank?
+
+    blocking_clippings = record.clippings.where(topic_id: previous_topic_id)
+    return unless blocking_clippings.exists?
+
+    record.errors.add(
+      :topic_id,
+      'cannot be changed while the news belongs to clippings for the current topic'
+    )
+  end
+
+  def validate_date_change(record)
+    new_date = record.date
+    blocking_clippings = record.clippings.where('start_date > ? OR end_date < ?', new_date, new_date)
+    return unless blocking_clippings.exists?
+
+    record.errors.add(
+      :date,
+      'cannot move outside the date range of linked clippings'
+    )
+  end
+end

--- a/app/validators/clipping_news_validator.rb
+++ b/app/validators/clipping_news_validator.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class ClippingNewsValidator < ActiveModel::Validator
+  def validate(record)
+    return if record.news_ids.blank?
+
+    validate_news_exist(record)
+    validate_news_belong_to_topic(record)
+    validate_news_within_date_range(record)
+  end
+
+  private
+
+  def validate_news_exist(record)
+    existing_ids = News.where(id: record.news_ids).pluck(:id)
+    missing_ids = record.news_ids - existing_ids
+    return if missing_ids.empty?
+
+    record.errors.add(
+      :news_ids,
+      "includes non-existent news: #{missing_ids.join(', ')}"
+    )
+  end
+
+  def validate_news_belong_to_topic(record)
+    return unless record.topic_id.present?
+
+    mismatched_news = News.where(id: record.news_ids).where.not(topic_id: record.topic_id)
+    return unless mismatched_news.exists?
+
+    record.errors.add(
+      :news_ids,
+      "must all belong to the clipping's topic (#{record.topic&.name})"
+    )
+  end
+
+  def validate_news_within_date_range(record)
+    return if record.start_date.blank? || record.end_date.blank?
+
+    out_of_range_news = News.where(id: record.news_ids)
+                            .where('date < ? OR date > ?', record.start_date, record.end_date)
+    return unless out_of_range_news.exists?
+
+    record.errors.add(
+      :news_ids,
+      "must have dates between #{record.start_date} and #{record.end_date}"
+    )
+  end
+end

--- a/app/validators/clipping_news_validator.rb
+++ b/app/validators/clipping_news_validator.rb
@@ -18,7 +18,8 @@ class ClippingNewsValidator < ActiveModel::Validator
 
     record.errors.add(
       :news_ids,
-      "includes non-existent news: #{missing_ids.join(', ')}"
+      :non_existent,
+      ids: missing_ids.join(', ')
     )
   end
 
@@ -30,7 +31,8 @@ class ClippingNewsValidator < ActiveModel::Validator
 
     record.errors.add(
       :news_ids,
-      "must all belong to the clipping's topic (#{record.topic&.name})"
+      :topic_mismatch,
+      topic_name: record.topic&.name
     )
   end
 
@@ -43,7 +45,9 @@ class ClippingNewsValidator < ActiveModel::Validator
 
     record.errors.add(
       :news_ids,
-      "must have dates between #{record.start_date} and #{record.end_date}"
+      :date_out_of_range,
+      start_date: record.start_date,
+      end_date: record.end_date
     )
   end
 end

--- a/app/views/api/v1/clippings/_clipping.json.jbuilder
+++ b/app/views/api/v1/clippings/_clipping.json.jbuilder
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
-json.extract! clipping, :id, :name, :start_date, :end_date, :topic_id, :news_ids, :created_at, :updated_at
-json.news_count clipping.news_count
+attributes = %i[id name start_date end_date topic_id news_ids created_at updated_at]
+attributes << :metrics if local_assigns.fetch(:include_metrics, false)
+
+json.extract! clipping, *attributes
 
 json.creator do
   json.id clipping.creator.id

--- a/app/views/api/v1/clippings/show.json.jbuilder
+++ b/app/views/api/v1/clippings/show.json.jbuilder
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-json.partial! 'clipping', clipping: @clipping
+json.partial! 'clipping', clipping: @clipping, include_metrics: true

--- a/app/views/api/v1/news/_news_item.json.jbuilder
+++ b/app/views/api/v1/news/_news_item.json.jbuilder
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 json.extract! news, :id, :title, :publication_type, :date, :support, :media, :section, :author, :interviewee, :link,
-              :audience_size, :quotation, :valuation, :political_factor, :plain_text, :created_at,
-              :updated_at
+              :audience_size, :quotation, :valuation, :political_factor, :created_at, :updated_at
 
 json.crisis news.crisis?
+
+json.requires_manual_review news.requires_manual_review?
 
 if news.topic.present?
   json.topic do

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,25 @@
 ---
 en:
+  activerecord:
+    errors:
+      models:
+        clipping:
+          attributes:
+            end_date:
+              before_start_date: must be on or after start date
+            news_ids:
+              blank: must include at least one news
+              non_existent: "includes non-existent news: %{ids}"
+              topic_mismatch: "must all belong to the clipping's topic (%{topic_name})"
+              date_out_of_range: "must have dates between %{start_date} and %{end_date}"
+            topic:
+              disabled: must be enabled
+        news:
+          attributes:
+            topic_id:
+              clipping_restriction: cannot be changed while the news belongs to clippings for the current topic
+            date:
+              clipping_bounds: cannot move outside the date range of linked clippings
   active_admin:
     dashboard: Main page
     dashboard_welcome:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,5 +1,25 @@
 ---
 es:
+  activerecord:
+    errors:
+      models:
+        clipping:
+          attributes:
+            end_date:
+              before_start_date: debe ser igual o posterior a la fecha de inicio
+            news_ids:
+              blank: debe incluir al menos una noticia
+              non_existent: "incluye noticias inexistentes: %{ids}"
+              topic_mismatch: "deben pertenecer al tema del clipping (%{topic_name})"
+              date_out_of_range: "deben tener fechas entre %{start_date} y %{end_date}"
+            topic:
+              disabled: debe estar habilitado
+        news:
+          attributes:
+            topic_id:
+              clipping_restriction: no se puede cambiar mientras la noticia pertenece a clippings del tema actual
+            date:
+              clipping_bounds: no se puede mover fuera del rango de fechas de los clippings asociados
   api:
     errors:
       invalid_content_type: Tipo de contenido inválido

--- a/db/migrate/20250908002938_add_metrics_to_clippings.rb
+++ b/db/migrate/20250908002938_add_metrics_to_clippings.rb
@@ -2,45 +2,7 @@
 
 class AddMetricsToClippings < ActiveRecord::Migration[8.0]
   def change
-    add_column :clippings, :metrics, :jsonb, null: false, default: default_metrics_structure
+    add_column :clippings, :metrics, :jsonb, null: false, default: {}
     add_index :clippings, :metrics, using: :gin
-  end
-
-  private
-
-  def default_metrics_structure
-    {
-      generated_at: nil,
-      date_range: {
-        from: nil,
-        to: nil
-      },
-      news_count: 0,
-      valuation: {
-        positive: { count: 0, percentage: 0.0 },
-        neutral: { count: 0, percentage: 0.0 },
-        negative: { count: 0, percentage: 0.0 },
-        total: 0
-      },
-      media_stats: {
-        total: 0,
-        items: []
-      },
-      support_stats: {
-        total: 0,
-        items: []
-      },
-      audience: {
-        total: nil,
-        average: nil,
-        max: nil
-      },
-      quotation: {
-        total: nil,
-        average: nil,
-        max: nil
-      },
-      crisis: false
-    }
   end
 end

--- a/db/migrate/20250908002938_add_metrics_to_clippings.rb
+++ b/db/migrate/20250908002938_add_metrics_to_clippings.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class AddMetricsToClippings < ActiveRecord::Migration[8.0]
+  def change
+    add_column :clippings, :metrics, :jsonb, null: false, default: default_metrics_structure
+    add_index :clippings, :metrics, using: :gin
+  end
+
+  private
+
+  def default_metrics_structure
+    {
+      generated_at: nil,
+      date_range: {
+        from: nil,
+        to: nil
+      },
+      news_count: 0,
+      valuation: {
+        positive: { count: 0, percentage: 0.0 },
+        neutral: { count: 0, percentage: 0.0 },
+        negative: { count: 0, percentage: 0.0 },
+        total: 0
+      },
+      media_stats: {
+        total: 0,
+        items: []
+      },
+      support_stats: {
+        total: 0,
+        items: []
+      },
+      audience: {
+        total: nil,
+        average: nil,
+        max: nil
+      },
+      quotation: {
+        total: nil,
+        average: nil,
+        max: nil
+      },
+      crisis: false
+    }
+  end
+end

--- a/db/migrate/20250908002939_create_clipping_news.rb
+++ b/db/migrate/20250908002939_create_clipping_news.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class CreateClippingNews < ActiveRecord::Migration[8.0]
+  def up
+    create_table :clipping_news do |t|
+      t.references :clipping, null: false, foreign_key: true
+      t.references :news, null: false, foreign_key: true
+      t.timestamps
+    end
+
+    add_index :clipping_news, [:clipping_id, :news_id], unique: true
+    add_index :clipping_news, :news_id
+
+    execute <<~SQL
+      INSERT INTO clipping_news (clipping_id, news_id, created_at, updated_at)
+      SELECT id, (jsonb_array_elements_text(news_ids))::bigint, NOW(), NOW()
+      FROM clippings
+      WHERE jsonb_array_length(news_ids) > 0;
+    SQL
+
+    remove_index :clippings, name: :index_clippings_on_news_ids
+    remove_column :clippings, :news_ids
+  end
+
+  def down
+    add_column :clippings, :news_ids, :jsonb, null: false, default: []
+    add_index :clippings, :news_ids, using: :gin
+
+    execute <<~SQL
+      UPDATE clippings
+      SET news_ids = COALESCE(
+        (
+          SELECT jsonb_agg(news_id ORDER BY news_id)
+          FROM clipping_news
+          WHERE clipping_id = clippings.id
+        ),
+        '[]'::jsonb
+      );
+    SQL
+
+    drop_table :clipping_news
+  end
+end

--- a/db/migrate/20250908002939_create_clipping_news.rb
+++ b/db/migrate/20250908002939_create_clipping_news.rb
@@ -1,43 +1,14 @@
 # frozen_string_literal: true
 
 class CreateClippingNews < ActiveRecord::Migration[8.0]
-  def up
+  def change
     create_table :clipping_news do |t|
       t.references :clipping, null: false, foreign_key: true
       t.references :news, null: false, foreign_key: true
       t.timestamps
     end
 
-    add_index :clipping_news, [:clipping_id, :news_id], unique: true
-    add_index :clipping_news, :news_id
-
-    execute <<~SQL
-      INSERT INTO clipping_news (clipping_id, news_id, created_at, updated_at)
-      SELECT id, (jsonb_array_elements_text(news_ids))::bigint, NOW(), NOW()
-      FROM clippings
-      WHERE jsonb_array_length(news_ids) > 0;
-    SQL
-
-    remove_index :clippings, name: :index_clippings_on_news_ids
-    remove_column :clippings, :news_ids
-  end
-
-  def down
-    add_column :clippings, :news_ids, :jsonb, null: false, default: []
-    add_index :clippings, :news_ids, using: :gin
-
-    execute <<~SQL
-      UPDATE clippings
-      SET news_ids = COALESCE(
-        (
-          SELECT jsonb_agg(news_id ORDER BY news_id)
-          FROM clipping_news
-          WHERE clipping_id = clippings.id
-        ),
-        '[]'::jsonb
-      );
-    SQL
-
-    drop_table :clipping_news
+    add_index :clipping_news, %i[clipping_id news_id], unique: true
+    remove_column :clippings, :news_ids, :jsonb, null: false, default: []
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_08_002937) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_08_002939) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -75,18 +75,28 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_08_002937) do
     t.index ["key"], name: "index_ai_configurations_on_key", unique: true
   end
 
+  create_table "clipping_news", force: :cascade do |t|
+    t.bigint "clipping_id", null: false
+    t.bigint "news_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["clipping_id", "news_id"], name: "index_clipping_news_on_clipping_id_and_news_id", unique: true
+    t.index ["clipping_id"], name: "index_clipping_news_on_clipping_id"
+    t.index ["news_id"], name: "index_clipping_news_on_news_id"
+  end
+
   create_table "clippings", force: :cascade do |t|
     t.string "name", null: false
     t.date "start_date", null: false
     t.date "end_date", null: false
-    t.jsonb "news_ids", default: [], null: false
     t.bigint "creator_id", null: false
     t.bigint "topic_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.jsonb "metrics", default: {}, null: false
     t.index ["creator_id"], name: "index_clippings_on_creator_id"
     t.index ["end_date"], name: "index_clippings_on_end_date"
-    t.index ["news_ids"], name: "index_clippings_on_news_ids", using: :gin
+    t.index ["metrics"], name: "index_clippings_on_metrics", using: :gin
     t.index ["start_date"], name: "index_clippings_on_start_date"
     t.index ["topic_id"], name: "index_clippings_on_topic_id"
   end
@@ -293,6 +303,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_08_002937) do
   end
 
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "clipping_news", "clippings"
+  add_foreign_key "clipping_news", "news"
   add_foreign_key "clippings", "topics"
   add_foreign_key "clippings", "users", column: "creator_id"
   add_foreign_key "mention_news", "mentions"

--- a/doc/PrensAI.postman_collection.json
+++ b/doc/PrensAI.postman_collection.json
@@ -839,7 +839,7 @@
 				{
 					"name": "Crear clipping",
 					"request": {
-					"description": "Crea un nuevo clipping en el sistema con un conjunto de noticias y fechas específicas. El usuario autenticado se asigna como creador.",
+					"description": "Crea un nuevo clipping en el sistema con un conjunto de noticias y fechas específicas. El usuario autenticado se asigna como creador. Requiere al menos un ID en `news_ids`.",
 						"method": "POST",
 						"header": [
 							{

--- a/doc/PrensAI.postman_collection.json
+++ b/doc/PrensAI.postman_collection.json
@@ -839,7 +839,7 @@
 				{
 					"name": "Crear clipping",
 					"request": {
-						"description": "Crea un nuevo clipping en el sistema con un conjunto de noticias y fechas específicas. El usuario autenticado se asigna como creador.",
+					"description": "Crea un nuevo clipping en el sistema con un conjunto de noticias y fechas específicas. El usuario autenticado se asigna como creador.",
 						"method": "POST",
 						"header": [
 							{
@@ -874,7 +874,7 @@
 				{
 					"name": "Obtener clipping",
 					"request": {
-						"description": "Obtiene los detalles completos de un clipping específico incluyendo información del creador y cantidad de noticias.",
+						"description": "Obtiene los detalles completos de un clipping específico, incluyendo métricas agregadas, información del creador y cantidad de noticias.",
 						"method": "GET",
 						"header": [],
 						"url": {

--- a/spec/factories/clipping_news.rb
+++ b/spec/factories/clipping_news.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :clipping_news do
+    clipping
+    news
+  end
+end

--- a/spec/factories/clippings.rb
+++ b/spec/factories/clippings.rb
@@ -3,10 +3,36 @@
 FactoryBot.define do
   factory :clipping do
     name { "Clipping #{SecureRandom.hex(3)}" }
-    start_date { Date.current }
-    end_date { Date.current + 1.day }
+    start_date { nil }
+    end_date { nil }
     topic
-    news_ids { [create(:news).id] }
     creator factory: :user
+
+    transient do
+      news_count { 1 }
+    end
+
+    after(:build) do |clipping, evaluator|
+      if clipping.news_ids.blank?
+        clipping.start_date ||= Date.current
+        clipping.end_date ||= clipping.start_date
+
+        news_items = create_list(
+          :news,
+          evaluator.news_count,
+          topic: clipping.topic,
+          date: clipping.start_date
+        )
+        clipping.news_ids = news_items.map(&:id)
+      else
+        news_records = News.where(id: clipping.news_ids)
+
+        clipping.topic ||= news_records.first&.topic
+        clipping.start_date ||= news_records.minimum(:date) || Date.current
+        clipping.end_date ||= news_records.maximum(:date) || clipping.start_date
+      end
+
+      clipping.end_date = clipping.start_date if clipping.end_date < clipping.start_date
+    end
   end
 end

--- a/spec/factories/news.rb
+++ b/spec/factories/news.rb
@@ -3,16 +3,19 @@
 FactoryBot.define do
   factory :news do
     title            { Faker::Lorem.sentence(word_count: 6) }
-    publication_type { %w[article interview editorial opinion].sample }
-    date             { Faker::Date.between(from: 1.year.ago, to: Date.current) }
-    support          { %w[positive negative neutral].sample }
-    media            { Faker::Company.name }
+    publication_type { %w[Declaración Agenda Entrevista Nota].sample }
+    date             { Faker::Date.between(from: '2025-01-01', to: Date.current) }
+    support          { %w[Grafica Digital].sample }
+    media            do
+      ['Clarín', 'La Nación', 'Infobae', 'Telam', 'La Gaceta', 'Pagina 12', 'El País', 'Perfil',
+       'Tiempo Argentino', 'TN', 'El Cronista'].sample
+    end
     plain_text       { Faker::Lorem.paragraph(sentence_count: 5) }
     author           { Faker::Name.name }
     interviewee      { Faker::Name.name }
     link             { Faker::Internet.url }
-    political_factor { %w[local regional national international].sample }
-    section          { %w[politics economy society sports culture].sample }
+    political_factor { %w[SI NO].sample }
+    section          { %w[Política Economía Sociedad Deportes Cultura].sample }
     valuation        { %w[positive neutral negative].sample }
     quotation        { Faker::Number.decimal(l_digits: 2, r_digits: 2) }
     audience_size    { Faker::Number.between(from: 1000, to: 1_000_000) }

--- a/spec/models/clipping_spec.rb
+++ b/spec/models/clipping_spec.rb
@@ -34,6 +34,15 @@ describe Clipping do
         expect(clipping.topic_id).to eq(topic.id)
       end
     end
+
+    context 'with an empty news list' do
+      it 'adds a validation error' do
+        clipping = described_class.new(base_attributes.merge(news_ids: [], topic_id: topic.id))
+
+        expect(clipping).not_to be_valid
+        expect(clipping.errors[:news_ids]).to include('must include at least one news')
+      end
+    end
   end
 
   describe 'callbacks' do

--- a/spec/models/clipping_spec.rb
+++ b/spec/models/clipping_spec.rb
@@ -34,25 +34,6 @@ describe Clipping do
         expect(clipping.topic_id).to eq(topic.id)
       end
     end
-
-    context 'with non positive or non numeric ids' do
-      it 'ignores invalid values and keeps valid news' do
-        clipping = described_class.new(base_attributes.merge(news_ids: [news.id, -1, 'foo'], topic_id: topic.id))
-
-        expect(clipping).to be_valid
-        expect(clipping.news_ids).to eq([news.id])
-      end
-    end
-
-    context 'with ids of news that do not exist' do
-      it 'adds a validation error' do
-        missing_id = News.maximum(:id).to_i + 1
-        clipping = described_class.new(base_attributes.merge(news_ids: [news.id, missing_id], topic_id: topic.id))
-
-        expect(clipping).not_to be_valid
-        expect(clipping.errors[:news_ids]).to include('must reference existing news')
-      end
-    end
   end
 
   describe 'callbacks' do
@@ -75,7 +56,7 @@ describe Clipping do
         expect(metrics[:generated_at]).to eq(Time.current.iso8601)
         expect(metrics[:valuation][:positive][:count]).to eq(1)
         expect(metrics[:valuation][:negative][:count]).to eq(1)
-        expect(clipping.reload.news.pluck(:id)).to match_array([positive_news.id, negative_news.id])
+        expect(clipping.reload.news.pluck(:id)).to contain_exactly(positive_news.id, negative_news.id)
       end
 
       neutral_news = create(:news, valuation: 'neutral')
@@ -88,7 +69,7 @@ describe Clipping do
         expect(refreshed_metrics[:generated_at]).to eq(Time.current.iso8601)
         expect(refreshed_metrics[:valuation][:negative][:count]).to eq(0)
         expect(refreshed_metrics[:valuation][:neutral][:count]).to eq(1)
-        expect(clipping.reload.news.pluck(:id)).to match_array([positive_news.id, neutral_news.id])
+        expect(clipping.reload.news.pluck(:id)).to contain_exactly(positive_news.id, neutral_news.id)
       end
     end
   end

--- a/spec/models/clipping_spec.rb
+++ b/spec/models/clipping_spec.rb
@@ -41,7 +41,9 @@ describe Clipping do
         clipping = described_class.new(base_attributes.merge(news_ids: [], topic_id: topic.id))
 
         expect(clipping).not_to be_valid
-        expect(clipping.errors[:news_ids]).to include('must include at least one news')
+        expect(clipping.errors[:news_ids]).to include(
+          I18n.t('activerecord.errors.models.clipping.attributes.news_ids.blank')
+        )
       end
     end
   end

--- a/spec/models/news_spec.rb
+++ b/spec/models/news_spec.rb
@@ -181,7 +181,7 @@ describe News do
       result = news.update(topic: another_topic)
 
       expect(result).to be_falsey
-      message = 'cannot be changed while the news belongs to clippings for the current topic'
+      message = I18n.t('activerecord.errors.models.news.attributes.topic_id.clipping_restriction')
       expect(news.errors[:topic_id]).to include(message)
       expect(news.reload.topic).to eq(original_topic)
     end
@@ -206,7 +206,8 @@ describe News do
       result = news.update(date: Date.new(2025, 2, 1))
 
       expect(result).to be_falsey
-      expect(news.errors[:date]).to include('cannot move outside the date range of linked clippings')
+      message = I18n.t('activerecord.errors.models.news.attributes.date.clipping_bounds')
+      expect(news.errors[:date]).to include(message)
       expect(news.reload.date).to eq(Date.new(2025, 1, 10))
     end
 

--- a/spec/models/news_spec.rb
+++ b/spec/models/news_spec.rb
@@ -181,7 +181,8 @@ describe News do
       result = news.update(topic: another_topic)
 
       expect(result).to be_falsey
-      expect(news.errors[:topic_id]).to include('cannot be changed while the news belongs to clippings for the current topic')
+      message = 'cannot be changed while the news belongs to clippings for the current topic'
+      expect(news.errors[:topic_id]).to include(message)
       expect(news.reload.topic).to eq(original_topic)
     end
 
@@ -199,7 +200,8 @@ describe News do
     it 'blocks moving the date outside linked clippings range' do
       topic = create(:topic)
       news = create(:news, topic: topic, date: Date.new(2025, 1, 10))
-      create(:clipping, topic: topic, start_date: Date.new(2025, 1, 1), end_date: Date.new(2025, 1, 15), news_ids: [news.id])
+      create(:clipping, topic: topic, start_date: Date.new(2025, 1, 1), end_date: Date.new(2025, 1, 15),
+                        news_ids: [news.id])
 
       result = news.update(date: Date.new(2025, 2, 1))
 
@@ -211,7 +213,8 @@ describe News do
     it 'allows changing the date within all linked clipping ranges' do
       topic = create(:topic)
       news = create(:news, topic: topic, date: Date.new(2025, 1, 10))
-      create(:clipping, topic: topic, start_date: Date.new(2025, 1, 1), end_date: Date.new(2025, 1, 15), news_ids: [news.id])
+      create(:clipping, topic: topic, start_date: Date.new(2025, 1, 1), end_date: Date.new(2025, 1, 15),
+                        news_ids: [news.id])
 
       expect(news.update(date: Date.new(2025, 1, 12))).to be_truthy
       expect(news.reload.date).to eq(Date.new(2025, 1, 12))

--- a/spec/models/news_spec.rb
+++ b/spec/models/news_spec.rb
@@ -1,10 +1,16 @@
 # frozen_string_literal: true
 
+require 'rails_helper'
+
 describe News do
+  include ActiveSupport::Testing::TimeHelpers
+
   describe 'associations' do
     it { is_expected.to belong_to(:topic).optional }
     it { is_expected.to have_many(:mention_news).dependent(:destroy) }
     it { is_expected.to have_many(:mentions).through(:mention_news) }
+    it { is_expected.to have_many(:clipping_news).dependent(:destroy) }
+    it { is_expected.to have_many(:clippings).through(:clipping_news) }
   end
 
   describe 'validations' do
@@ -37,6 +43,39 @@ describe News do
   end
 
   describe 'callbacks' do
+    context 'when metric attributes change' do
+      let(:topic) { create(:topic) }
+      let!(:news) do
+        create(
+          :news,
+          topic: topic,
+          valuation: 'neutral',
+          media: 'Clarín',
+          support: 'Print',
+          date: Date.new(2025, 1, 2),
+          audience_size: 1_000,
+          quotation: 150.5
+        )
+      end
+      let!(:clipping) { create(:clipping, topic: topic, news_ids: [news.id]) }
+
+      it 'refreshes metrics for related clippings' do
+        initial_generated_at = clipping.metrics['generated_at']
+
+        travel_to Time.zone.local(2025, 1, 3, 9, 15) do
+          news.update!(valuation: 'positive', media: 'La Nación')
+        end
+
+        clipping.reload
+        expect(clipping.metrics['generated_at']).not_to eq(initial_generated_at)
+        expect(clipping.metrics['generated_at']).to eq(Time.zone.local(2025, 1, 3, 9, 15).iso8601)
+        expect(clipping.metrics['valuation']['positive']['count']).to eq(1)
+        expect(clipping.metrics['media_stats']['items']).to contain_exactly(
+          { 'key' => 'La Nación', 'count' => 1, 'percentage' => 100.0 }
+        )
+      end
+    end
+
     context 'when news is created' do
       let(:topic) { create(:topic) }
       let(:news) { build(:news, topic: topic) }
@@ -129,6 +168,53 @@ describe News do
     it 'returns true when a required field is nil' do
       field = %i[valuation topic].sample
       expect(build(:news, valid_attributes.merge(field => nil)).requires_manual_review?).to be true
+    end
+  end
+
+  describe '#prevent_topic_change_when_clipped' do
+    it 'blocks topic changes when the news belongs to a clipping of the current topic' do
+      original_topic = create(:topic)
+      another_topic = create(:topic)
+      news = create(:news, topic: original_topic)
+      create(:clipping, topic: original_topic, news_ids: [news.id])
+
+      result = news.update(topic: another_topic)
+
+      expect(result).to be_falsey
+      expect(news.errors[:topic_id]).to include('cannot be changed while the news belongs to clippings for the current topic')
+      expect(news.reload.topic).to eq(original_topic)
+    end
+
+    it 'allows topic changes when there are no clippings for the current topic' do
+      original_topic = create(:topic)
+      another_topic = create(:topic)
+      news = create(:news, topic: original_topic)
+
+      expect(news.update(topic: another_topic)).to be_truthy
+      expect(news.reload.topic).to eq(another_topic)
+    end
+  end
+
+  describe '#ensure_date_within_clipping_bounds' do
+    it 'blocks moving the date outside linked clippings range' do
+      topic = create(:topic)
+      news = create(:news, topic: topic, date: Date.new(2025, 1, 10))
+      create(:clipping, topic: topic, start_date: Date.new(2025, 1, 1), end_date: Date.new(2025, 1, 15), news_ids: [news.id])
+
+      result = news.update(date: Date.new(2025, 2, 1))
+
+      expect(result).to be_falsey
+      expect(news.errors[:date]).to include('cannot move outside the date range of linked clippings')
+      expect(news.reload.date).to eq(Date.new(2025, 1, 10))
+    end
+
+    it 'allows changing the date within all linked clipping ranges' do
+      topic = create(:topic)
+      news = create(:news, topic: topic, date: Date.new(2025, 1, 10))
+      create(:clipping, topic: topic, start_date: Date.new(2025, 1, 1), end_date: Date.new(2025, 1, 15), news_ids: [news.id])
+
+      expect(news.update(date: Date.new(2025, 1, 12))).to be_truthy
+      expect(news.reload.date).to eq(Date.new(2025, 1, 12))
     end
   end
 end

--- a/spec/policies/clipping_policy_spec.rb
+++ b/spec/policies/clipping_policy_spec.rb
@@ -9,33 +9,22 @@ describe ClippingPolicy do
   let(:clipping) { build_stubbed(:clipping, creator:) }
 
   permissions :index?, :show?, :create? do
-    it 'grants access to admins' do
+    it 'allows authenticated users' do
       expect(policy).to permit(admin, clipping)
-    end
-
-    it 'grants access to regular users' do
       expect(policy).to permit(creator, clipping)
+      expect(policy).to permit(other_user, clipping)
     end
 
-    it 'denies access to guests' do
+    it 'denies unauthenticated users' do
       expect(policy).not_to permit(nil, clipping)
     end
   end
 
   permissions :update?, :destroy? do
-    it 'grants access to admins' do
+    it 'allows admins and creators but denies others' do
       expect(policy).to permit(admin, clipping)
-    end
-
-    it 'grants access to the creator' do
       expect(policy).to permit(creator, clipping)
-    end
-
-    it 'denies access to a different regular user' do
       expect(policy).not_to permit(other_user, clipping)
-    end
-
-    it 'denies access to guests' do
       expect(policy).not_to permit(nil, clipping)
     end
   end

--- a/spec/requests/api/v1/clippings/create_spec.rb
+++ b/spec/requests/api/v1/clippings/create_spec.rb
@@ -6,7 +6,7 @@ describe 'POST /api/v1/clippings' do
   include_context 'with authenticated admin user via JWT'
 
   let(:topic) { create(:topic) }
-  let(:news) { create_list(:news, 2) }
+  let(:news) { create_list(:news, 2, topic: topic, date: Date.current) }
 
   let(:valid_params) do
     {

--- a/spec/requests/api/v1/clippings/update_spec.rb
+++ b/spec/requests/api/v1/clippings/update_spec.rb
@@ -4,7 +4,7 @@ describe 'PUT /api/v1/clippings/:id' do
   subject(:request_update) { put api_v1_clipping_path(clipping.id), params:, headers: auth_headers, as: :json }
 
   let(:topic) { create(:topic) }
-  let(:news) { create_list(:news, 2) }
+  let(:news) { create_list(:news, 2, topic: topic, date: Date.current) }
 
   let(:valid_params) do
     {

--- a/spec/services/clippings/metrics_builder_spec.rb
+++ b/spec/services/clippings/metrics_builder_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe Clippings::MetricsBuilder, type: :service do
   describe '.call' do
     context 'when the clipping has associated news' do
       let(:topic) { create(:topic) }
+      let(:alpha_mention) { create(:mention, name: 'Alpha') }
+      let(:beta_mention) { create(:mention, name: 'Beta') }
+      let(:gamma_mention) { create(:mention, name: 'Gamma') }
       let(:news_items) do
         [
           create(
@@ -18,7 +21,8 @@ RSpec.describe Clippings::MetricsBuilder, type: :service do
             support: 'Print',
             date: Date.new(2025, 1, 2),
             audience_size: 1_000,
-            quotation: 120.5
+            quotation: 120.5,
+            mentions: [alpha_mention, beta_mention]
           ),
           create(
             :news,
@@ -28,7 +32,8 @@ RSpec.describe Clippings::MetricsBuilder, type: :service do
             support: 'Print',
             date: Date.new(2025, 1, 5),
             audience_size: 2_000,
-            quotation: 80.25
+            quotation: 80.25,
+            mentions: [alpha_mention]
           ),
           create(
             :news,
@@ -38,7 +43,8 @@ RSpec.describe Clippings::MetricsBuilder, type: :service do
             support: 'Digital',
             date: Date.new(2025, 1, 1),
             audience_size: nil,
-            quotation: 210.75
+            quotation: 210.75,
+            mentions: [gamma_mention]
           )
         ]
       end
@@ -114,6 +120,17 @@ RSpec.describe Clippings::MetricsBuilder, type: :service do
           total: 411.5,
           average: 137.17,
           max: { news_id: negative_news.id, value: 210.75 }
+        )
+      end
+
+      it 'aggregates mention metrics with counts and percentages' do
+        expect(metrics[:mention_stats]).to eq(
+          total: 4,
+          items: [
+            { mention_id: alpha_mention.id, name: 'Alpha', count: 2, percentage: 50.0 },
+            { mention_id: beta_mention.id, name: 'Beta', count: 1, percentage: 25.0 },
+            { mention_id: gamma_mention.id, name: 'Gamma', count: 1, percentage: 25.0 }
+          ]
         )
       end
 

--- a/spec/services/clippings/metrics_builder_spec.rb
+++ b/spec/services/clippings/metrics_builder_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Clippings::MetricsBuilder, type: :service do
+  include ActiveSupport::Testing::TimeHelpers
+
+  describe '.call' do
+    it 'aggregates metrics for the provided clipping news' do
+      topic = create(:topic, crisis: true)
+      positive_news = create(
+        :news,
+        topic: topic,
+        valuation: 'positive',
+        media: 'Clarín',
+        support: 'Print',
+        date: Date.new(2025, 1, 2),
+        audience_size: 1_000,
+        quotation: 120.5
+      )
+      neutral_news = create(
+        :news,
+        topic: topic,
+        valuation: 'neutral',
+        media: 'Clarín',
+        support: 'Print',
+        date: Date.new(2025, 1, 5),
+        audience_size: 2_000,
+        quotation: 80.25
+      )
+      negative_news = create(
+        :news,
+        topic: topic,
+        valuation: 'negative',
+        media: 'La Nación',
+        support: 'Digital',
+        date: Date.new(2025, 1, 1),
+        audience_size: nil,
+        quotation: 210.75
+      )
+
+      clipping = build(
+        :clipping,
+        topic: topic,
+        news_ids: [positive_news.id, neutral_news.id, negative_news.id],
+        start_date: Date.new(2025, 1, 1),
+        end_date: Date.new(2025, 1, 7)
+      )
+
+      travel_to Time.zone.local(2025, 1, 10, 9, 30) do
+        metrics = described_class.call(clipping)
+
+        expect(metrics[:generated_at]).to eq(Time.current.iso8601)
+        expect(metrics[:news_count]).to eq(3)
+        expect(metrics[:date_range]).to eq(from: Date.new(2025, 1, 1), to: Date.new(2025, 1, 5))
+
+        expect(metrics[:valuation]).to eq(
+          positive: { count: 1, percentage: 33.33 },
+          neutral: { count: 1, percentage: 33.33 },
+          negative: { count: 1, percentage: 33.33 },
+          total: 3
+        )
+
+        expect(metrics[:media_stats][:total]).to eq(3)
+        expect(metrics[:media_stats][:items]).to contain_exactly(
+          { key: 'Clarín', count: 2, percentage: 66.67 },
+          { key: 'La Nación', count: 1, percentage: 33.33 }
+        )
+
+        expect(metrics[:support_stats][:total]).to eq(3)
+        expect(metrics[:support_stats][:items]).to contain_exactly(
+          { key: 'Print', count: 2, percentage: 66.67 },
+          { key: 'Digital', count: 1, percentage: 33.33 }
+        )
+
+        expect(metrics[:audience]).to eq(
+          total: 3_000,
+          average: 1_500.0,
+          max: { news_id: neutral_news.id, value: 2_000 }
+        )
+
+        expect(metrics[:quotation]).to eq(
+          total: 411.5,
+          average: 137.17,
+          max: { news_id: negative_news.id, value: 210.75 }
+        )
+
+        expect(metrics[:crisis]).to be(true)
+      end
+    end
+
+    it 'returns default values when there are no news ids' do
+      clipping = build(:clipping, news_ids: [])
+
+      travel_to Time.zone.local(2025, 1, 1, 12, 0) do
+        metrics = described_class.call(clipping)
+
+        expect(metrics[:generated_at]).to eq(Time.current.iso8601)
+        expect(metrics[:news_count]).to eq(0)
+        expect(metrics[:date_range]).to eq(from: nil, to: nil)
+        expect(metrics[:valuation]).to eq(
+          positive: { count: 0, percentage: 0.0 },
+          neutral: { count: 0, percentage: 0.0 },
+          negative: { count: 0, percentage: 0.0 },
+          total: 0
+        )
+        expect(metrics[:media_stats]).to eq(total: 0, items: [])
+        expect(metrics[:support_stats]).to eq(total: 0, items: [])
+        expect(metrics[:audience]).to eq(total: nil, average: nil, max: nil)
+        expect(metrics[:quotation]).to eq(total: nil, average: nil, max: nil)
+        expect(metrics[:crisis]).to be(false)
+      end
+    end
+  end
+end

--- a/spec/services/clippings/metrics_builder_spec.rb
+++ b/spec/services/clippings/metrics_builder_spec.rb
@@ -6,118 +6,120 @@ RSpec.describe Clippings::MetricsBuilder, type: :service do
   include ActiveSupport::Testing::TimeHelpers
 
   describe '.call' do
-    it 'aggregates metrics for the provided clipping news' do
-      topic = create(:topic, crisis: true)
-      positive_news = create(
-        :news,
-        topic: topic,
-        valuation: 'positive',
-        media: 'Clarín',
-        support: 'Print',
-        date: Date.new(2025, 1, 2),
-        audience_size: 1_000,
-        quotation: 120.5
-      )
-      neutral_news = create(
-        :news,
-        topic: topic,
-        valuation: 'neutral',
-        media: 'Clarín',
-        support: 'Print',
-        date: Date.new(2025, 1, 5),
-        audience_size: 2_000,
-        quotation: 80.25
-      )
-      negative_news = create(
-        :news,
-        topic: topic,
-        valuation: 'negative',
-        media: 'La Nación',
-        support: 'Digital',
-        date: Date.new(2025, 1, 1),
-        audience_size: nil,
-        quotation: 210.75
-      )
+    context 'when the clipping has associated news' do
+      let(:topic) { create(:topic) }
+      let(:creator) { create(:user) }
+      let!(:positive_news) do
+        create(
+          :news,
+          topic: topic,
+          valuation: 'positive',
+          media: 'Clarín',
+          support: 'Print',
+          date: Date.new(2025, 1, 2),
+          audience_size: 1_000,
+          quotation: 120.5
+        )
+      end
+      let!(:neutral_news) do
+        create(
+          :news,
+          topic: topic,
+          valuation: 'neutral',
+          media: 'Clarín',
+          support: 'Print',
+          date: Date.new(2025, 1, 5),
+          audience_size: 2_000,
+          quotation: 80.25
+        )
+      end
+      let!(:negative_news) do
+        create(
+          :news,
+          topic: topic,
+          valuation: 'negative',
+          media: 'La Nación',
+          support: 'Digital',
+          date: Date.new(2025, 1, 1),
+          audience_size: nil,
+          quotation: 210.75
+        )
+      end
+      let(:clipping) do
+        create(
+          :clipping,
+          name: 'Metrics sample',
+          start_date: Date.new(2025, 1, 1),
+          end_date: Date.new(2025, 1, 7),
+          topic: topic,
+          creator: creator,
+          news_ids: [positive_news.id, neutral_news.id, negative_news.id]
+        )
+      end
+      let(:frozen_time) { Time.zone.local(2025, 1, 10, 9, 30) }
+      let(:metrics) { travel_to(frozen_time) { described_class.call(clipping) } }
 
-      clipping = Clipping.new(
-        name: 'Metrics sample',
-        start_date: Date.new(2025, 1, 1),
-        end_date: Date.new(2025, 1, 7),
-        topic: topic,
-        creator: create(:user)
-      )
-      clipping.news = [positive_news, neutral_news, negative_news]
+      before { allow(clipping.topic).to receive(:crisis?).and_return(true) }
 
-      allow(topic).to receive(:crisis?).and_return(true)
+      it 'sets generated_at with the current time' do
+        expect(metrics[:generated_at]).to eq(frozen_time.iso8601)
+      end
 
-      travel_to Time.zone.local(2025, 1, 10, 9, 30) do
-        metrics = described_class.call(clipping)
-
-        expect(metrics[:generated_at]).to eq(Time.current.iso8601)
+      it 'counts the news used for the clipping' do
         expect(metrics[:news_count]).to eq(3)
-        expect(metrics[:date_range]).to eq(from: Date.new(2025, 1, 1), to: Date.new(2025, 1, 5))
+      end
 
+      it 'reports the date range covered by the news' do
+        expect(metrics[:date_range]).to eq(from: Date.new(2025, 1, 1), to: Date.new(2025, 1, 5))
+      end
+
+      it 'builds the valuation breakdown' do
         expect(metrics[:valuation]).to eq(
           positive: { count: 1, percentage: 33.33 },
           neutral: { count: 1, percentage: 33.33 },
           negative: { count: 1, percentage: 33.33 },
           total: 3
         )
+      end
 
-        expect(metrics[:media_stats][:total]).to eq(3)
-        expect(metrics[:media_stats][:items]).to contain_exactly(
-          { key: 'Clarín', count: 2, percentage: 66.67 },
-          { key: 'La Nación', count: 1, percentage: 33.33 }
+      it 'groups metrics by media outlet' do
+        expect(metrics[:media_stats]).to eq(
+          total: 3,
+          items: [
+            { key: 'Clarín', count: 2, percentage: 66.67 },
+            { key: 'La Nación', count: 1, percentage: 33.33 }
+          ]
         )
+      end
 
-        expect(metrics[:support_stats][:total]).to eq(3)
-        expect(metrics[:support_stats][:items]).to contain_exactly(
-          { key: 'Print', count: 2, percentage: 66.67 },
-          { key: 'Digital', count: 1, percentage: 33.33 }
+      it 'groups metrics by support type' do
+        expect(metrics[:support_stats]).to eq(
+          total: 3,
+          items: [
+            { key: 'Print', count: 2, percentage: 66.67 },
+            { key: 'Digital', count: 1, percentage: 33.33 }
+          ]
         )
+      end
 
+      it 'aggregates audience values' do
         expect(metrics[:audience]).to eq(
           total: 3_000,
           average: 1_500.0,
           max: { news_id: neutral_news.id, value: 2_000 }
         )
+      end
 
+      it 'aggregates quotation values' do
         expect(metrics[:quotation]).to eq(
           total: 411.5,
           average: 137.17,
           max: { news_id: negative_news.id, value: 210.75 }
         )
-
-        expect(metrics[:crisis]).to be(true)
       end
-    end
 
-    it 'returns default values when there are no news ids' do
-      clipping = Clipping.new(
-        name: 'Empty clipping',
-        start_date: Date.new(2025, 1, 1),
-        end_date: Date.new(2025, 1, 7),
-        topic: create(:topic),
-        creator: create(:user)
-      )
-
-      travel_to Time.zone.local(2025, 1, 1, 12, 0) do
-        metrics = described_class.call(clipping)
-
-        expect(metrics[:generated_at]).to eq(Time.current.iso8601)
-        expect(metrics[:news_count]).to eq(0)
-        expect(metrics[:date_range]).to eq(from: nil, to: nil)
-        expect(metrics[:valuation]).to eq(
-          positive: { count: 0, percentage: 0.0 },
-          neutral: { count: 0, percentage: 0.0 },
-          negative: { count: 0, percentage: 0.0 },
-          total: 0
-        )
-        expect(metrics[:media_stats]).to eq(total: 0, items: [])
-        expect(metrics[:support_stats]).to eq(total: 0, items: [])
-        expect(metrics[:audience]).to eq(total: nil, average: nil, max: nil)
-        expect(metrics[:quotation]).to eq(total: nil, average: nil, max: nil)
-        expect(metrics[:crisis]).to be(false)
+      it 'reflects the crisis status of the associated topic' do
+        expect(metrics[:crisis]).to be(true)
       end
     end
   end

--- a/spec/services/clippings/metrics_builder_spec.rb
+++ b/spec/services/clippings/metrics_builder_spec.rb
@@ -39,13 +39,16 @@ RSpec.describe Clippings::MetricsBuilder, type: :service do
         quotation: 210.75
       )
 
-      clipping = build(
-        :clipping,
-        topic: topic,
-        news_ids: [positive_news.id, neutral_news.id, negative_news.id],
+      clipping = Clipping.new(
+        name: 'Metrics sample',
         start_date: Date.new(2025, 1, 1),
-        end_date: Date.new(2025, 1, 7)
+        end_date: Date.new(2025, 1, 7),
+        topic: topic,
+        creator: create(:user)
       )
+      clipping.news = [positive_news, neutral_news, negative_news]
+
+      allow(topic).to receive(:crisis?).and_return(true)
 
       travel_to Time.zone.local(2025, 1, 10, 9, 30) do
         metrics = described_class.call(clipping)
@@ -90,7 +93,13 @@ RSpec.describe Clippings::MetricsBuilder, type: :service do
     end
 
     it 'returns default values when there are no news ids' do
-      clipping = build(:clipping, news_ids: [])
+      clipping = Clipping.new(
+        name: 'Empty clipping',
+        start_date: Date.new(2025, 1, 1),
+        end_date: Date.new(2025, 1, 7),
+        topic: create(:topic),
+        creator: create(:user)
+      )
 
       travel_to Time.zone.local(2025, 1, 1, 12, 0) do
         metrics = described_class.call(clipping)

--- a/spec/services/clippings/metrics_builder_spec.rb
+++ b/spec/services/clippings/metrics_builder_spec.rb
@@ -8,42 +8,39 @@ RSpec.describe Clippings::MetricsBuilder, type: :service do
   describe '.call' do
     context 'when the clipping has associated news' do
       let(:topic) { create(:topic) }
-      let(:creator) { create(:user) }
-      let!(:positive_news) do
-        create(
-          :news,
-          topic: topic,
-          valuation: 'positive',
-          media: 'Clarín',
-          support: 'Print',
-          date: Date.new(2025, 1, 2),
-          audience_size: 1_000,
-          quotation: 120.5
-        )
-      end
-      let!(:neutral_news) do
-        create(
-          :news,
-          topic: topic,
-          valuation: 'neutral',
-          media: 'Clarín',
-          support: 'Print',
-          date: Date.new(2025, 1, 5),
-          audience_size: 2_000,
-          quotation: 80.25
-        )
-      end
-      let!(:negative_news) do
-        create(
-          :news,
-          topic: topic,
-          valuation: 'negative',
-          media: 'La Nación',
-          support: 'Digital',
-          date: Date.new(2025, 1, 1),
-          audience_size: nil,
-          quotation: 210.75
-        )
+      let(:news_items) do
+        [
+          create(
+            :news,
+            topic: topic,
+            valuation: 'positive',
+            media: 'Clarín',
+            support: 'Print',
+            date: Date.new(2025, 1, 2),
+            audience_size: 1_000,
+            quotation: 120.5
+          ),
+          create(
+            :news,
+            topic: topic,
+            valuation: 'neutral',
+            media: 'Clarín',
+            support: 'Print',
+            date: Date.new(2025, 1, 5),
+            audience_size: 2_000,
+            quotation: 80.25
+          ),
+          create(
+            :news,
+            topic: topic,
+            valuation: 'negative',
+            media: 'La Nación',
+            support: 'Digital',
+            date: Date.new(2025, 1, 1),
+            audience_size: nil,
+            quotation: 210.75
+          )
+        ]
       end
       let(:clipping) do
         create(
@@ -52,8 +49,8 @@ RSpec.describe Clippings::MetricsBuilder, type: :service do
           start_date: Date.new(2025, 1, 1),
           end_date: Date.new(2025, 1, 7),
           topic: topic,
-          creator: creator,
-          news_ids: [positive_news.id, neutral_news.id, negative_news.id]
+          creator: create(:user),
+          news_ids: news_items.pluck(:id)
         )
       end
       let(:frozen_time) { Time.zone.local(2025, 1, 10, 9, 30) }
@@ -103,6 +100,7 @@ RSpec.describe Clippings::MetricsBuilder, type: :service do
       end
 
       it 'aggregates audience values' do
+        neutral_news = news_items.find { |news| news.valuation == 'neutral' }
         expect(metrics[:audience]).to eq(
           total: 3_000,
           average: 1_500.0,
@@ -111,6 +109,7 @@ RSpec.describe Clippings::MetricsBuilder, type: :service do
       end
 
       it 'aggregates quotation values' do
+        negative_news = news_items.find { |news| news.valuation == 'negative' }
         expect(metrics[:quotation]).to eq(
           total: 411.5,
           average: 137.17,

--- a/spec/validators/clipping_constraints_validator_spec.rb
+++ b/spec/validators/clipping_constraints_validator_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ClippingConstraintsValidator do
+  describe '#validate' do
+    let(:topic) { create(:topic) }
+    let(:another_topic) { create(:topic) }
+    let(:news) { create(:news, topic: topic, date: Date.new(2025, 1, 15)) }
+
+    context 'when news is not in any clipping' do
+      it 'allows topic change' do
+        news.topic = another_topic
+        expect(news).to be_valid
+      end
+
+      it 'allows date change' do
+        news.date = Date.new(2025, 2, 1)
+        expect(news).to be_valid
+      end
+    end
+
+    context 'when news belongs to a clipping' do
+      let(:clipping) do
+        create(:clipping,
+               topic: topic,
+               start_date: Date.new(2025, 1, 1),
+               end_date: Date.new(2025, 1, 31),
+               news_ids: [news.id])
+      end
+
+      before { clipping }
+
+      context 'with topic validation' do
+        it 'prevents changing topic when clipping uses the current topic' do
+          news.topic = another_topic
+          expect(news).not_to be_valid
+          expect(news.errors[:topic_id]).to include(
+            'cannot be changed while the news belongs to clippings for the current topic'
+          )
+        end
+
+        it 'allows changing topic when clipping is updated to different topic first' do
+          clipping.update!(topic: another_topic)
+
+          new_topic = create(:topic)
+          news.topic = new_topic
+
+          expect(news).to be_valid
+        end
+      end
+
+      context 'with date validation' do
+        it 'prevents moving date outside clipping range (before start)' do
+          news.date = Date.new(2024, 12, 31)
+          expect(news).not_to be_valid
+          expect(news.errors[:date]).to include(
+            'cannot move outside the date range of linked clippings'
+          )
+        end
+
+        it 'prevents moving date outside clipping range (after end)' do
+          news.date = Date.new(2025, 2, 1)
+          expect(news).not_to be_valid
+          expect(news.errors[:date]).to include(
+            'cannot move outside the date range of linked clippings'
+          )
+        end
+
+        it 'allows moving date within clipping range' do
+          news.date = Date.new(2025, 1, 20)
+          expect(news).to be_valid
+        end
+
+        it 'allows moving date on clipping boundaries' do
+          news.date = Date.new(2025, 1, 1)
+          expect(news).to be_valid
+
+          news.date = Date.new(2025, 1, 31)
+          expect(news).to be_valid
+        end
+      end
+    end
+
+    context 'when creating a new news record' do
+      it 'does not run clipping validations' do
+        new_news = build(:news, topic: topic, date: Date.new(2025, 1, 1))
+        expect(new_news).to be_valid
+      end
+    end
+  end
+end

--- a/spec/validators/clipping_constraints_validator_spec.rb
+++ b/spec/validators/clipping_constraints_validator_spec.rb
@@ -36,15 +36,14 @@ RSpec.describe ClippingConstraintsValidator do
           news.topic = another_topic
           expect(news).not_to be_valid
           expect(news.errors[:topic_id]).to include(
-            'cannot be changed while the news belongs to clippings for the current topic'
+            I18n.t('activerecord.errors.models.news.attributes.topic_id.clipping_restriction')
           )
         end
 
-        it 'allows changing topic when clipping is updated to different topic first' do
-          clipping.update!(topic: another_topic)
+        it 'allows changing topic after destroying clipping' do
+          clipping.destroy!
 
-          new_topic = create(:topic)
-          news.topic = new_topic
+          news.topic = another_topic
 
           expect(news).to be_valid
         end
@@ -55,7 +54,7 @@ RSpec.describe ClippingConstraintsValidator do
           news.date = Date.new(2024, 12, 31)
           expect(news).not_to be_valid
           expect(news.errors[:date]).to include(
-            'cannot move outside the date range of linked clippings'
+            I18n.t('activerecord.errors.models.news.attributes.date.clipping_bounds')
           )
         end
 
@@ -63,7 +62,7 @@ RSpec.describe ClippingConstraintsValidator do
           news.date = Date.new(2025, 2, 1)
           expect(news).not_to be_valid
           expect(news.errors[:date]).to include(
-            'cannot move outside the date range of linked clippings'
+            I18n.t('activerecord.errors.models.news.attributes.date.clipping_bounds')
           )
         end
 

--- a/spec/validators/clipping_news_validator_spec.rb
+++ b/spec/validators/clipping_news_validator_spec.rb
@@ -45,7 +45,8 @@ RSpec.describe ClippingNewsValidator do
 
         expect(clipping).not_to be_valid
         expect(clipping.errors[:news_ids]).to include(
-          "must all belong to the clipping's topic (Transport)"
+          I18n.t('activerecord.errors.models.clipping.attributes.news_ids.topic_mismatch',
+                 topic_name: topic.name)
         )
       end
     end
@@ -78,7 +79,8 @@ RSpec.describe ClippingNewsValidator do
 
         expect(clipping).not_to be_valid
         expect(clipping.errors[:news_ids]).to include(
-          'must have dates between 2025-01-01 and 2025-01-31'
+          I18n.t('activerecord.errors.models.clipping.attributes.news_ids.date_out_of_range',
+                 start_date: Date.new(2025, 1, 1), end_date: Date.new(2025, 1, 31))
         )
       end
     end

--- a/spec/validators/clipping_news_validator_spec.rb
+++ b/spec/validators/clipping_news_validator_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ClippingNewsValidator do
+  describe '#validate' do
+    let(:topic) { create(:topic, name: 'Transport') }
+    let(:another_topic) { create(:topic, name: 'Health') }
+    let(:creator) { create(:user) }
+    let(:news_in_topic) do
+      create(:news, topic: topic, date: Date.new(2025, 1, 15))
+    end
+    let(:news_different_topic) do
+      create(:news, topic: another_topic, date: Date.new(2025, 1, 16))
+    end
+    let(:news_outside_range) do
+      create(:news, topic: topic, date: Date.new(2025, 2, 1))
+    end
+
+    context 'when all news belong to the clipping topic' do
+      it 'is valid' do
+        clipping = Clipping.new(
+          name: 'Test Clipping',
+          topic: topic,
+          creator: creator,
+          start_date: Date.new(2025, 1, 1),
+          end_date: Date.new(2025, 1, 31),
+          news_ids: [news_in_topic.id]
+        )
+
+        expect(clipping).to be_valid
+      end
+    end
+
+    context 'when some news do not belong to the clipping topic' do
+      it 'adds validation error' do
+        clipping = Clipping.new(
+          name: 'Test Clipping',
+          topic: topic,
+          creator: creator,
+          start_date: Date.new(2025, 1, 1),
+          end_date: Date.new(2025, 1, 31),
+          news_ids: [news_in_topic.id, news_different_topic.id]
+        )
+
+        expect(clipping).not_to be_valid
+        expect(clipping.errors[:news_ids]).to include(
+          "must all belong to the clipping's topic (Transport)"
+        )
+      end
+    end
+
+    context 'when all news are within date range' do
+      it 'is valid' do
+        clipping = Clipping.new(
+          name: 'Test Clipping',
+          topic: topic,
+          creator: creator,
+          start_date: Date.new(2025, 1, 1),
+          end_date: Date.new(2025, 1, 31),
+          news_ids: [news_in_topic.id]
+        )
+
+        expect(clipping).to be_valid
+      end
+    end
+
+    context 'when some news are outside date range' do
+      it 'adds validation error' do
+        clipping = Clipping.new(
+          name: 'Test Clipping',
+          topic: topic,
+          creator: creator,
+          start_date: Date.new(2025, 1, 1),
+          end_date: Date.new(2025, 1, 31),
+          news_ids: [news_in_topic.id, news_outside_range.id]
+        )
+
+        expect(clipping).not_to be_valid
+        expect(clipping.errors[:news_ids]).to include(
+          'must have dates between 2025-01-01 and 2025-01-31'
+        )
+      end
+    end
+
+    context 'when news is on boundary dates' do
+      let(:news_on_start) { create(:news, topic: topic, date: Date.new(2025, 1, 1)) }
+      let(:news_on_end) { create(:news, topic: topic, date: Date.new(2025, 1, 31)) }
+
+      it 'is valid' do
+        clipping = Clipping.new(
+          name: 'Test Clipping',
+          topic: topic,
+          creator: creator,
+          start_date: Date.new(2025, 1, 1),
+          end_date: Date.new(2025, 1, 31),
+          news_ids: [news_on_start.id, news_on_end.id]
+        )
+
+        expect(clipping).to be_valid
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Métricas de clippings
- Generación: Clippings::MetricsBuilder calcula métricas al guardar un clipping
o cuando cambian sus noticias asociadas, produciendo un JSON persistido.
- Contenido: Incluye sello temporal (generated_at), rango de fechas, cantidad
de noticias, distribuciones por valoración, medio y soporte, estadísticas de
menciones y agregados numéricos de audiencia y cotización, además del estado de
crisis del tema.
- Actualización: Al modificar relaciones clipping ↔ news o atributos relevantes
de una noticia (valuation, media, support, date, audience_size, quotation), se
recomputan para mantener la vista en tiempo real.

### Actualización de métricas
Son sincrónicas. Suceden en los siguientes momentos:
   - Persistencia del clipping: Clipping recalcula métricas en cada save gracias al
callback before_save :assign_metrics.
   - Cambios en vínculos: ClippingNews ejecuta refresh_clipping_metrics (que llama
a clipping.refresh_metrics!) después de crear o eliminar una relación con una
noticia.
   - Actualización de noticias: News vuelve a generar métricas de los clippings
asociados en after_commit cuando cambia cualquiera de los atributos que impactan
las métricas (valuation, media, support, date, audience_size, quotation).

### Validaciones:
- Clipping: Se añadió longitud mínima/máxima al nombre, se mantiene que las
fechas existan y end_date no sea previa al inicio pero con mensaje localizado;
ahora exige al menos un news_id, requiere que el tema esté habilitado y delega
en ClippingNewsValidator para verificar existencia de noticias, pertenencia al
mismo tema y fechas dentro del rango del clipping.
- ClippingNews: Nueva asociación con validación de unicidad por [clipping_id,
news_id] para evitar duplicados.
- News: Se incorporó ClippingConstraintsValidator en actualización para impedir
cambiar el tema si la noticia participa en clippings del tema actual y para
bloquear fechas fuera de los rangos definidos por esos clippings; solo se evalúa
cuando la noticia ya existe.

### Otros cambios:
- Migraciones: Se incorporó metrics en clippings y la tabla intermedia
clipping_news, removiendo el JSON news_ids.
- Servicios y validadores: Se añadió Clippings::MetricsBuilder para generar
estadísticas; nuevos validadores controlan restricciones de clipping y noticias.
- Internacionalización: Nuevos mensajes de error en config/locales/en.yml
y es.yml.
- Tests y factories: Se ajustaron factories y specs para el nuevo flujo de
métricas, asociaciones y reglas de validación.
- Documentación API: Se actualizó apiary.apib y Postman para reflejar métricas
agregadas del clipping, eliminar news_count plano y exigir al menos un news_id. 