### PR TITLE
fix: fix clipping endpoints

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -680,96 +680,18 @@ Crea un nuevo clipping en el sistema con un conjunto de noticias y fechas espec�
         }
 
 + Response 201 (application/json)
-    + Attributes (ClippingShow)
+    + Attributes (ClippingSimple)
     + Body
         {
-            "id": 1,
-            "name": "Clipping Semanal Transporte",
-            "start_date": "2025-01-01",
-            "end_date": "2025-01-07",
-            "topic": {
+            "clipping": {
                 "id": 1,
-                "name": "Transporte"
-            },
-            "news": [
-                {
-                    "id": 1,
-                    "title": "Título de la noticia",
-                    "publication_type": "article",
-                    "date": "2025-01-02",
-                    "support": "web",
-                    "media": "Nombre del medio",
-                    "section": "Política",
-                    "author": "Autor/a",
-                    "interviewee": null,
-                    "link": "https://ejemplo.com/noticia",
-                    "audience_size": 10000,
-                    "quotation": null,
-                    "valuation": "neutral",
-                    "political_factor": "local",
-                    "created_at": "2025-01-09T10:30:00Z",
-                    "updated_at": "2025-01-09T10:30:00Z",
-                    "crisis": false,
-                    "requires_manual_review": false,
-                    "topic": {
-                        "id": 1,
-                        "name": "Transporte"
-                    },
-                    "mentions": [],
-                    "creator": null,
-                    "reviewer": null
-                }
-            ],
-            "has_report": false,
-            "metrics": {
-                "generated_at": "2025-01-09T10:30:00Z",
-                "date_range": { "from": "2025-01-01", "to": "2025-01-07" },
-                "news_count": 3,
-                "valuation": {
-                    "positive": { "count": 1, "percentage": 33.33 },
-                    "neutral": { "count": 1, "percentage": 33.33 },
-                    "negative": { "count": 1, "percentage": 33.33 },
-                    "total": 3
-                },
-                "media_stats": {
-                    "total": 3,
-                    "items": [
-                        { "key": "Clarín", "count": 2, "percentage": 66.67 },
-                        { "key": "La Nación", "count": 1, "percentage": 33.33 }
-                    ]
-                },
-                "support_stats": {
-                    "total": 3,
-                    "items": [
-                        { "key": "Print", "count": 2, "percentage": 66.67 },
-                        { "key": "Digital", "count": 1, "percentage": 33.33 }
-                    ]
-                },
-                "mention_stats": {
-                    "total": 4,
-                    "items": [
-                        { "mention_id": 1, "name": "Ministerio de Transporte", "count": 2, "percentage": 50.0 },
-                        { "mention_id": 2, "name": "Jorge Macri", "count": 1, "percentage": 25.0 },
-                        { "mention_id": 3, "name": "Gabriela Ricardes", "count": 1, "percentage": 25.0 }
-                    ]
-                },
-                "audience": {
-                    "total": 3000,
-                    "average": 1500.0,
-                    "max": { "news_id": 2, "value": 2000 }
-                },
-                "quotation": {
-                    "total": 411.5,
-                    "average": 137.17,
-                    "max": { "news_id": 3, "value": 210.75 }
-                },
-                "crisis": false
-            },
-            "created_at": "2025-01-09T10:30:00Z",
-            "updated_at": "2025-01-09T10:30:00Z",
-            "creator": {
-                "id": 1,
-                "name": "Juan Pérez"
+                "name": "Clipping Semanal Transporte",
+                "start_date": "2025-01-01",
+                "end_date": "2025-01-07",
+                "topic_id": 1,
+                "news_ids": [1, 2, 3],
+                "created_at": "2025-01-09T10:30:00Z",
+                "updated_at": "2025-01-09T10:30:00Z"
             }
         }
 
@@ -825,7 +747,20 @@ Actualiza un clipping existente. **Permisos:** Solo el creador del clipping o un
         }
 
 + Response 200 (application/json)
-    + Attributes (ClippingShow)
+    + Attributes (ClippingSimple)
+    + Body
+        {
+            "clipping": {
+                "id": 1,
+                "name": "Clipping Actualizado",
+                "start_date": "2025-01-01",
+                "end_date": "2025-01-07",
+                "topic_id": 1,
+                "news_ids": [1, 2, 3, 4],
+                "created_at": "2025-01-09T10:30:00Z",
+                "updated_at": "2025-01-10T08:15:00Z"
+            }
+        }
 
 + Response 401 (application/json)
     + Attributes
@@ -1792,8 +1727,18 @@ Recibe un conjunto de noticias **ya clasificadas** por el backend y genera un in
 + news_ids: [1, 2, 3] (array[number]) - IDs de las noticias incluidas en el clipping. Disponible en listados para filtrar o consultar rápidamente.
 
 ### ClippingShow (ClippingBase)
-+ news (array[NewsItem]) - Noticias completas asociadas al clipping. Incluido en los endpoints de detalle, creación y actualización.
-+ metrics (ClippingMetrics, optional) - Métricas agregadas del clipping. Disponible en los endpoints de detalle, creación y actualización.
++ news (array[NewsItem]) - Noticias completas asociadas al clipping. Incluido en el endpoint de detalle.
++ metrics (ClippingMetrics, optional) - Métricas agregadas del clipping. Disponible en el endpoint de detalle.
+
+### ClippingSimple (object)
++ id: 1 (number) - ID único del clipping recién procesado
++ name: "Clipping Semanal Transporte" (string) - Nombre del clipping
++ start_date: "2025-01-01" (string) - Fecha de inicio del período (ISO 8601)
++ end_date: "2025-01-07" (string) - Fecha de fin del período (ISO 8601)
++ topic_id: 1 (number) - ID del tema asociado
++ news_ids: [1, 2, 3] (array[number]) - IDs de las noticias vinculadas
++ created_at: "2025-01-09T10:30:00Z" (string) - Fecha de creación (ISO 8601)
++ updated_at: "2025-01-09T10:30:00Z" (string) - Fecha de última actualización (ISO 8601)
 
 ### ClippingMetrics (object)
 + generated_at: "2025-01-09T10:30:00Z" (string) - Momento del último cálculo (ISO 8601)

--- a/apiary.apib
+++ b/apiary.apib
@@ -643,7 +643,8 @@ Obtiene una lista paginada de todos los clippings en el sistema, ordenados por f
                     "creator": {
                         "id": 1,
                         "name": "Juan Pérez"
-                    }
+                    },
+                    "reviewer": null
                 }
             ],
             "pagination": {
@@ -683,16 +684,16 @@ Crea un nuevo clipping en el sistema con un conjunto de noticias y fechas espec�
     + Attributes (ClippingSimple)
     + Body
         {
-            "clipping": {
-                "id": 1,
-                "name": "Clipping Semanal Transporte",
-                "start_date": "2025-01-01",
-                "end_date": "2025-01-07",
-                "topic_id": 1,
-                "news_ids": [1, 2, 3],
-                "created_at": "2025-01-09T10:30:00Z",
-                "updated_at": "2025-01-09T10:30:00Z"
-            }
+            "id": 1,
+            "name": "Clipping Semanal Transporte",
+            "start_date": "2025-01-01",
+            "end_date": "2025-01-07",
+            "topic_id": 1,
+            "news_ids": [1, 2, 3],
+            "created_at": "2025-01-09T10:30:00Z",
+            "updated_at": "2025-01-09T10:30:00Z",
+            "creator_id": 1,
+            "reviewer_id": 1            
         }
 
 + Response 401 (application/json)
@@ -750,16 +751,16 @@ Actualiza un clipping existente. **Permisos:** Solo el creador del clipping o un
     + Attributes (ClippingSimple)
     + Body
         {
-            "clipping": {
-                "id": 1,
-                "name": "Clipping Actualizado",
-                "start_date": "2025-01-01",
-                "end_date": "2025-01-07",
-                "topic_id": 1,
-                "news_ids": [1, 2, 3, 4],
-                "created_at": "2025-01-09T10:30:00Z",
-                "updated_at": "2025-01-10T08:15:00Z"
-            }
+            "id": 1,
+            "name": "Clipping Actualizado",
+            "start_date": "2025-01-01",
+            "end_date": "2025-01-07",
+            "topic_id": 1,
+            "news_ids": [1, 2, 3, 4],
+            "created_at": "2025-01-09T10:30:00Z",
+            "updated_at": "2025-01-10T08:15:00Z",
+            "creator_id": 1,
+            "reviewer_id": 1
         }
 
 + Response 401 (application/json)
@@ -1722,6 +1723,7 @@ Recibe un conjunto de noticias **ya clasificadas** por el backend y genera un in
 + created_at: "2025-01-09T10:30:00Z" (string) - Fecha de creación (ISO 8601)
 + updated_at: "2025-01-09T10:30:00Z" (string) - Fecha de última actualización (ISO 8601)
 + creator (EntityRef) - Usuario que creó el clipping
++ reviewer (EntityRef, nullable) - Usuario que revisó el clipping por última vez
 
 ### ClippingIndex (ClippingBase)
 + news_ids: [1, 2, 3] (array[number]) - IDs de las noticias incluidas en el clipping. Disponible en listados para filtrar o consultar rápidamente.
@@ -1739,6 +1741,8 @@ Recibe un conjunto de noticias **ya clasificadas** por el backend y genera un in
 + news_ids: [1, 2, 3] (array[number]) - IDs de las noticias vinculadas
 + created_at: "2025-01-09T10:30:00Z" (string) - Fecha de creación (ISO 8601)
 + updated_at: "2025-01-09T10:30:00Z" (string) - Fecha de última actualización (ISO 8601)
++ creator_id: 1 (number) - ID único del creador
++ reviewer_id: 1 (number) - ID único del último editor
 
 ### ClippingMetrics (object)
 + generated_at: "2025-01-09T10:30:00Z" (string) - Momento del último cálculo (ISO 8601)

--- a/apiary.apib
+++ b/apiary.apib
@@ -606,7 +606,7 @@ Actualiza una noticia existente. Requiere autenticación y el usuario debe tener
 
 ### Listar Clippings [GET]
 
-Obtiene una lista paginada de todos los clippings en el sistema, ordenados por fecha de creación descendente.
+Obtiene una lista paginada de todos los clippings en el sistema, ordenados por fecha de creación descendente. Cada clipping incluye `topic` (objeto con ID y nombre) y el flag `has_report`.
 
 **Parámetros de filtrado disponibles:**
 - `topic_id`: Filtrar por tema específico
@@ -620,7 +620,7 @@ Obtiene una lista paginada de todos los clippings en el sistema, ordenados por f
 
 + Response 200 (application/json)
     + Attributes
-        + clippings (array[Clipping])
+        + clippings (array[ClippingIndex])
         + pagination (Pagination)
         
     + Body
@@ -632,7 +632,10 @@ Obtiene una lista paginada de todos los clippings en el sistema, ordenados por f
                     "name": "Clipping Semanal Transporte",
                     "start_date": "2025-01-01",
                     "end_date": "2025-01-07",
-                    "topic_id": 1,
+                    "topic": {
+                        "id": 1,
+                        "name": "Transporte"
+                    },
                     "news_ids": [1, 2, 3],
                     "has_report": true,
                     "created_at": "2025-01-09T10:30:00Z",
@@ -677,15 +680,46 @@ Crea un nuevo clipping en el sistema con un conjunto de noticias y fechas espec�
         }
 
 + Response 201 (application/json)
-    + Attributes (Clipping)
+    + Attributes (ClippingShow)
     + Body
         {
             "id": 1,
             "name": "Clipping Semanal Transporte",
             "start_date": "2025-01-01",
             "end_date": "2025-01-07",
-            "topic_id": 1,
-            "news_ids": [1, 2, 3],
+            "topic": {
+                "id": 1,
+                "name": "Transporte"
+            },
+            "news": [
+                {
+                    "id": 1,
+                    "title": "Título de la noticia",
+                    "publication_type": "article",
+                    "date": "2025-01-02",
+                    "support": "web",
+                    "media": "Nombre del medio",
+                    "section": "Política",
+                    "author": "Autor/a",
+                    "interviewee": null,
+                    "link": "https://ejemplo.com/noticia",
+                    "audience_size": 10000,
+                    "quotation": null,
+                    "valuation": "neutral",
+                    "political_factor": "local",
+                    "created_at": "2025-01-09T10:30:00Z",
+                    "updated_at": "2025-01-09T10:30:00Z",
+                    "crisis": false,
+                    "requires_manual_review": false,
+                    "topic": {
+                        "id": 1,
+                        "name": "Transporte"
+                    },
+                    "mentions": [],
+                    "creator": null,
+                    "reviewer": null
+                }
+            ],
             "has_report": false,
             "metrics": {
                 "generated_at": "2025-01-09T10:30:00Z",
@@ -759,7 +793,7 @@ Obtiene los detalles de un clipping específico.
         Authorization: Bearer {jwt_token}
 
 + Response 200 (application/json)
-    + Attributes (Clipping)
+    + Attributes (ClippingShow)
 
 + Response 401 (application/json)
     + Attributes
@@ -791,7 +825,7 @@ Actualiza un clipping existente. **Permisos:** Solo el creador del clipping o un
         }
 
 + Response 200 (application/json)
-    + Attributes (Clipping)
+    + Attributes (ClippingShow)
 
 + Response 401 (application/json)
     + Attributes
@@ -1743,17 +1777,22 @@ Recibe un conjunto de noticias **ya clasificadas** por el backend y genera un in
 + created_at: "2025-01-09T10:30:00Z" (string) - Fecha de creación (ISO 8601)
 + updated_at: "2025-01-09T10:30:00Z" (string) - Fecha de última actualización (ISO 8601)
 
-### Clipping (object)
+### ClippingBase (object)
 + id: 1 (number) - ID único del clipping
 + name: "Clipping Semanal Transporte" (string) - Nombre del clipping
 + start_date: "2025-01-01" (string) - Fecha de inicio del período (ISO 8601)
 + end_date: "2025-01-07" (string) - Fecha de fin del período (ISO 8601)
-+ topic_id: 1 (number) - ID del tema asociado
-+ news_ids: [1, 2, 3] (array[number]) - Array de IDs de noticias incluidas
++ topic (EntityRef) - Tema asociado al clipping (incluye id y nombre)
 + has_report: true (boolean) - Indica si el clipping tiene un reporte generado
 + created_at: "2025-01-09T10:30:00Z" (string) - Fecha de creación (ISO 8601)
 + updated_at: "2025-01-09T10:30:00Z" (string) - Fecha de última actualización (ISO 8601)
 + creator (EntityRef) - Usuario que creó el clipping
+
+### ClippingIndex (ClippingBase)
++ news_ids: [1, 2, 3] (array[number]) - IDs de las noticias incluidas en el clipping. Disponible en listados para filtrar o consultar rápidamente.
+
+### ClippingShow (ClippingBase)
++ news (array[NewsItem]) - Noticias completas asociadas al clipping. Incluido en los endpoints de detalle, creación y actualización.
 + metrics (ClippingMetrics, optional) - Métricas agregadas del clipping. Disponible en los endpoints de detalle, creación y actualización.
 
 ### ClippingMetrics (object)

--- a/app/controllers/api/v1/clippings_controller.rb
+++ b/app/controllers/api/v1/clippings_controller.rb
@@ -8,7 +8,7 @@ module API
       def index
         scoped = policy_scope(Clipping)
                  .filter_by(filtering_params)
-                 .includes(:news, :topic)
+                 .includes(clipping_includes)
                  .ordered
         @pagy, @clippings = pagy(scoped)
       end
@@ -38,7 +38,7 @@ module API
       private
 
       def set_clipping
-        @clipping = Clipping.includes(:news, :topic, :report).find(params[:id])
+        @clipping = Clipping.includes(clipping_includes).find(params[:id])
       end
 
       def clipping_params
@@ -55,6 +55,15 @@ module API
 
       def filtering_params
         params.permit(:topic_id, :start_date, :end_date, news_ids: [])
+      end
+
+      def clipping_includes
+        [
+          :topic,
+          :report,
+          :creator,
+          { news: %i[topic mentions creator reviewer] }
+        ]
       end
     end
   end

--- a/app/controllers/api/v1/clippings_controller.rb
+++ b/app/controllers/api/v1/clippings_controller.rb
@@ -8,7 +8,7 @@ module API
       def index
         scoped = policy_scope(Clipping)
                  .filter_by(filtering_params)
-                 .includes(:news)
+                 .includes(:news, :topic)
                  .ordered
         @pagy, @clippings = pagy(scoped)
       end

--- a/app/controllers/api/v1/clippings_controller.rb
+++ b/app/controllers/api/v1/clippings_controller.rb
@@ -20,13 +20,13 @@ module API
       def create
         @clipping = authorize Clipping.new(clipping_params.merge(creator: current_user))
         @clipping.save!
-        render :show, status: :created
+        render :create, status: :created
       end
 
       def update
         authorize @clipping
         @clipping.update!(clipping_params)
-        render :show, status: :ok
+        render :update, status: :ok
       end
 
       def destroy

--- a/app/controllers/api/v1/clippings_controller.rb
+++ b/app/controllers/api/v1/clippings_controller.rb
@@ -25,7 +25,7 @@ module API
 
       def update
         authorize @clipping
-        @clipping.update!(clipping_params)
+        @clipping.update!(clipping_params.merge(reviewer: current_user))
         render :update, status: :ok
       end
 
@@ -62,6 +62,7 @@ module API
           :topic,
           :report,
           :creator,
+          :reviewer,
           { news: %i[topic mentions creator reviewer] }
         ]
       end

--- a/app/models/clipping.rb
+++ b/app/models/clipping.rb
@@ -4,27 +4,30 @@
 #
 # Table name: clippings
 #
-#  id         :bigint           not null, primary key
-#  end_date   :date             not null
-#  metrics    :jsonb            not null
-#  name       :string           not null
-#  start_date :date             not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  creator_id :bigint           not null
-#  topic_id   :bigint           not null
+#  id          :bigint           not null, primary key
+#  end_date    :date             not null
+#  metrics     :jsonb            not null
+#  name        :string           not null
+#  start_date  :date             not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  creator_id  :bigint           not null
+#  reviewer_id :bigint
+#  topic_id    :bigint           not null
 #
 # Indexes
 #
-#  index_clippings_on_creator_id  (creator_id)
-#  index_clippings_on_end_date    (end_date)
-#  index_clippings_on_metrics     (metrics) USING gin
-#  index_clippings_on_start_date  (start_date)
-#  index_clippings_on_topic_id    (topic_id)
+#  index_clippings_on_creator_id   (creator_id)
+#  index_clippings_on_end_date     (end_date)
+#  index_clippings_on_metrics      (metrics) USING gin
+#  index_clippings_on_reviewer_id  (reviewer_id)
+#  index_clippings_on_start_date   (start_date)
+#  index_clippings_on_topic_id     (topic_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (creator_id => users.id)
+#  fk_rails_...  (reviewer_id => users.id)
 #  fk_rails_...  (topic_id => topics.id)
 #
 class Clipping < ApplicationRecord
@@ -32,6 +35,7 @@ class Clipping < ApplicationRecord
 
   belongs_to :creator, class_name: 'User'
   belongs_to :topic
+  belongs_to :reviewer, class_name: 'User', optional: true
 
   has_many :clipping_news, dependent: :destroy
   has_many :news, through: :clipping_news

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,6 +36,8 @@ class User < ApplicationRecord
 
   has_many :news, foreign_key: :creator_id, dependent: :nullify, inverse_of: :creator
   has_many :reviewed_news, class_name: 'News', foreign_key: :reviewer_id, dependent: :nullify, inverse_of: :reviewer
+  has_many :reviewed_clippings, class_name: 'Clipping', foreign_key: :reviewer_id, dependent: :nullify,
+                                inverse_of: :reviewer
 
   validates :role, presence: true, inclusion: { in: %w[admin user] }
 

--- a/app/validators/clipping_news_validator.rb
+++ b/app/validators/clipping_news_validator.rb
@@ -24,7 +24,7 @@ class ClippingNewsValidator < ActiveModel::Validator
   end
 
   def validate_news_belong_to_topic(record)
-    return unless record.topic_id.present?
+    return if record.topic_id.blank?
 
     mismatched_news = News.where(id: record.news_ids).where.not(topic_id: record.topic_id)
     return unless mismatched_news.exists?

--- a/app/views/api/v1/clippings/_clipping.json.jbuilder
+++ b/app/views/api/v1/clippings/_clipping.json.jbuilder
@@ -30,3 +30,12 @@ json.creator do
   json.id clipping.creator.id
   json.name clipping.creator.full_name
 end
+
+if clipping.reviewer.present?
+  json.reviewer do
+    json.id clipping.reviewer.id
+    json.name clipping.reviewer.full_name
+  end
+else
+  json.reviewer nil
+end

--- a/app/views/api/v1/clippings/_clipping.json.jbuilder
+++ b/app/views/api/v1/clippings/_clipping.json.jbuilder
@@ -1,11 +1,30 @@
 # frozen_string_literal: true
 
-attributes = %i[id name start_date end_date topic_id news_ids created_at updated_at]
+include_news = local_assigns.fetch(:include_news, false)
+include_news_ids = local_assigns.fetch(:include_news_ids, !include_news)
+
+attributes = %i[id name start_date end_date created_at updated_at]
 attributes << :metrics if local_assigns.fetch(:include_metrics, false)
+attributes << :news_ids if include_news_ids
 
 json.extract! clipping, *attributes
 
 json.has_report clipping.report.present?
+
+if clipping.topic.present?
+  json.topic do
+    json.id clipping.topic.id
+    json.name clipping.topic.name
+  end
+else
+  json.topic nil
+end
+
+if include_news
+  json.news clipping.news do |news|
+    json.partial! 'api/v1/news/news_item', news: news
+  end
+end
 
 json.creator do
   json.id clipping.creator.id

--- a/app/views/api/v1/clippings/_clipping_summary.json.jbuilder
+++ b/app/views/api/v1/clippings/_clipping_summary.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.extract! clipping, :id, :name, :start_date, :end_date, :topic_id, :news_ids, :created_at, :updated_at

--- a/app/views/api/v1/clippings/_clipping_summary.json.jbuilder
+++ b/app/views/api/v1/clippings/_clipping_summary.json.jbuilder
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
-json.extract! clipping, :id, :name, :start_date, :end_date, :topic_id, :news_ids, :created_at, :updated_at
+json.extract! clipping, :id, :name, :start_date, :end_date, :topic_id, :news_ids, :created_at, :updated_at,
+              :creator_id, :reviewer_id

--- a/app/views/api/v1/clippings/create.json.jbuilder
+++ b/app/views/api/v1/clippings/create.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! 'clipping_summary', clipping: @clipping

--- a/app/views/api/v1/clippings/reports/_report.json.jbuilder
+++ b/app/views/api/v1/clippings/reports/_report.json.jbuilder
@@ -8,20 +8,20 @@ json.manually_edited report.manually_edited?
 json.created_at report.created_at.iso8601
 json.updated_at report.updated_at.iso8601
 
-      if report.creator.present?
-        json.creator do
-          json.id report.creator.id
-          json.name report.creator.full_name
-        end
-      else
-        json.creator nil
-      end
+if report.creator.present?
+  json.creator do
+    json.id report.creator.id
+    json.name report.creator.full_name
+  end
+else
+  json.creator nil
+end
 
-      if report.reviewer.present?
-        json.reviewer do
-          json.id report.reviewer.id
-          json.name report.reviewer.full_name
-        end
-      else
-        json.reviewer nil
-      end
+if report.reviewer.present?
+  json.reviewer do
+    json.id report.reviewer.id
+    json.name report.reviewer.full_name
+  end
+else
+  json.reviewer nil
+end

--- a/app/views/api/v1/clippings/show.json.jbuilder
+++ b/app/views/api/v1/clippings/show.json.jbuilder
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-json.partial! 'clipping', clipping: @clipping, include_metrics: true
+json.partial! 'clipping', clipping: @clipping, include_metrics: true, include_news: true

--- a/app/views/api/v1/clippings/update.json.jbuilder
+++ b/app/views/api/v1/clippings/update.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! 'clipping_summary', clipping: @clipping

--- a/db/migrate/20251016060000_add_editor_and_reviewer_to_clippings.rb
+++ b/db/migrate/20251016060000_add_editor_and_reviewer_to_clippings.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddEditorAndReviewerToClippings < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :clippings, :reviewer, foreign_key: { to_table: :users }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_16_051748) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_16_060000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -107,9 +107,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_16_051748) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.jsonb "metrics", default: {}, null: false
+    t.bigint "reviewer_id"
     t.index ["creator_id"], name: "index_clippings_on_creator_id"
     t.index ["end_date"], name: "index_clippings_on_end_date"
     t.index ["metrics"], name: "index_clippings_on_metrics", using: :gin
+    t.index ["reviewer_id"], name: "index_clippings_on_reviewer_id"
     t.index ["start_date"], name: "index_clippings_on_start_date"
     t.index ["topic_id"], name: "index_clippings_on_topic_id"
   end
@@ -323,6 +325,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_16_051748) do
   add_foreign_key "clipping_reports", "users", column: "reviewer_id"
   add_foreign_key "clippings", "topics"
   add_foreign_key "clippings", "users", column: "creator_id"
+  add_foreign_key "clippings", "users", column: "reviewer_id"
   add_foreign_key "mention_news", "mentions"
   add_foreign_key "mention_news", "news"
   add_foreign_key "news", "topics"

--- a/doc/PrensAI.postman_collection.json
+++ b/doc/PrensAI.postman_collection.json
@@ -801,7 +801,7 @@
 				{
 					"name": "Listar clippings",
 					"request": {
-						"description": "Obtiene una lista paginada de todos los clippings del sistema ordenados por fecha de creación descendente. Incluye filtros por tema, fechas y noticias específicas. Cada clipping incluye el campo has_report que indica si tiene un reporte generado.",
+						"description": "Obtiene una lista paginada de todos los clippings del sistema ordenados por fecha de creación descendente. Incluye filtros por tema, fechas y noticias específicas. Cada clipping devuelve `has_report` y `topic` (objeto con id y name).",
 						"method": "GET",
 						"header": [],
 						"url": {
@@ -839,7 +839,7 @@
 				{
 					"name": "Crear clipping",
 					"request": {
-					"description": "Crea un nuevo clipping en el sistema con un conjunto de noticias y fechas específicas. El usuario autenticado se asigna como creador. Requiere al menos un ID en `news_ids`.",
+					"description": "Crea un nuevo clipping en el sistema con un conjunto de noticias y fechas específicas. El usuario autenticado se asigna como creador. Requiere al menos un ID en `news_ids`. La respuesta expone `topic` (id y name) y el arreglo completo de `news` asociadas.",
 						"method": "POST",
 						"header": [
 							{
@@ -874,7 +874,7 @@
 				{
 					"name": "Obtener clipping",
 					"request": {
-						"description": "Obtiene los detalles completos de un clipping específico, incluyendo métricas agregadas, información del creador, cantidad de noticias y estado del reporte (has_report).",
+						"description": "Obtiene los detalles completos de un clipping específico, incluyendo métricas agregadas, información del creador, `topic` (id y name), el arreglo completo de `news` y el estado del reporte (`has_report`).",
 						"method": "GET",
 						"header": [],
 						"url": {

--- a/doc/PrensAI.postman_collection.json
+++ b/doc/PrensAI.postman_collection.json
@@ -801,7 +801,7 @@
 				{
 					"name": "Listar clippings",
 					"request": {
-						"description": "Obtiene una lista paginada de todos los clippings del sistema ordenados por fecha de creación descendente. Incluye filtros por tema, fechas y noticias específicas. Cada clipping devuelve `has_report` y `topic` (objeto con id y name).",
+						"description": "Obtiene una lista paginada de todos los clippings del sistema ordenados por fecha de creación descendente. Incluye filtros por tema, fechas y noticias específicas.",
 						"method": "GET",
 						"header": [],
 						"url": {
@@ -839,7 +839,7 @@
 				{
 					"name": "Crear clipping",
 					"request": {
-					"description": "Crea un nuevo clipping en el sistema con un conjunto de noticias y fechas específicas. El usuario autenticado se asigna como creador. Requiere al menos un ID en `news_ids`. La respuesta expone `topic` (id y name) y el arreglo completo de `news` asociadas.",
+					"description": "Crea un nuevo clipping en el sistema con un conjunto de noticias y fechas específicas. El usuario autenticado se asigna como creador. Requiere al menos un ID en `news_ids`.",
 						"method": "POST",
 						"header": [
 							{
@@ -874,7 +874,7 @@
 				{
 					"name": "Obtener clipping",
 					"request": {
-						"description": "Obtiene los detalles completos de un clipping específico, incluyendo métricas agregadas, información del creador, `topic` (id y name), el arreglo completo de `news` y el estado del reporte (`has_report`).",
+						"description": "Obtiene los detalles completos de un clipping específico, incluyendo métricas agregadas, información del creador, su último revisor, `topic` (id y name), el arreglo completo de `news` y el estado del reporte (`has_report`).",
 						"method": "GET",
 						"header": [],
 						"url": {

--- a/spec/requests/api/v1/clippings/create_spec.rb
+++ b/spec/requests/api/v1/clippings/create_spec.rb
@@ -50,6 +50,8 @@ describe 'POST /api/v1/clippings' do
       expect(json[:name]).to eq('Weekly Summary')
       expect(json[:topic_id]).to eq(topic.id)
       expect(json[:news_ids]).to match_array(news.map(&:id))
+      expect(json[:creator_id]).to eq(admin_user.id)
+      expect(json[:reviewer_id]).to be_nil
     end
   end
 

--- a/spec/requests/api/v1/clippings/create_spec.rb
+++ b/spec/requests/api/v1/clippings/create_spec.rb
@@ -48,12 +48,8 @@ describe 'POST /api/v1/clippings' do
       request_create
       expect(json[:id]).to be_present
       expect(json[:name]).to eq('Weekly Summary')
-      expect(json[:topic]).to include(id: topic.id, name: topic.name)
-      expect(json[:news]).to be_an(Array)
-      expect(json[:news].pluck(:id)).to match_array(news.map(&:id))
-      expect(json[:creator]).to include(:id, :name)
-      expect(json).not_to have_key(:news_ids)
-      expect(json).not_to have_key(:topic_id)
+      expect(json[:topic_id]).to eq(topic.id)
+      expect(json[:news_ids]).to match_array(news.map(&:id))
     end
   end
 

--- a/spec/requests/api/v1/clippings/create_spec.rb
+++ b/spec/requests/api/v1/clippings/create_spec.rb
@@ -48,9 +48,12 @@ describe 'POST /api/v1/clippings' do
       request_create
       expect(json[:id]).to be_present
       expect(json[:name]).to eq('Weekly Summary')
-      expect(json[:topic_id]).to eq(topic.id)
-      expect(json[:news_ids]).to match_array(news.map(&:id))
+      expect(json[:topic]).to include(id: topic.id, name: topic.name)
+      expect(json[:news]).to be_an(Array)
+      expect(json[:news].pluck(:id)).to match_array(news.map(&:id))
       expect(json[:creator]).to include(:id, :name)
+      expect(json).not_to have_key(:news_ids)
+      expect(json).not_to have_key(:topic_id)
     end
   end
 

--- a/spec/requests/api/v1/clippings/index_spec.rb
+++ b/spec/requests/api/v1/clippings/index_spec.rb
@@ -41,13 +41,14 @@ describe 'GET /api/v1/clippings' do
     expect(json[:clippings].pluck(:id)).to eq([clipping_recent.id, clipping_old.id])
   end
 
-  it 'includes topic and news ids in each clipping', :aggregate_failures do
+  it 'includes topic details and news ids in each clipping', :aggregate_failures do
     request_index
     payload = json[:clippings].first
 
-    expect(payload[:topic_id]).to eq(topics.first.id)
+    expect(payload[:topic]).to include(id: topics.first.id, name: topics.first.name)
     expect(payload[:news_ids]).to match_array(topic_one_news.map(&:id))
     expect(payload[:creator]).to include(:id, :name)
+    expect(payload).not_to have_key(:topic_id)
   end
 
   it 'returns pagination metadata' do
@@ -77,7 +78,7 @@ describe 'GET /api/v1/clippings' do
         request_index
         expect(json[:clippings].size).to eq(1)
         expect(json[:clippings].first[:id]).to eq(clipping_recent.id)
-        expect(json[:clippings].first[:topic_id]).to eq(topics.first.id)
+        expect(json[:clippings].first[:topic][:id]).to eq(topics.first.id)
       end
     end
 

--- a/spec/requests/api/v1/clippings/index_spec.rb
+++ b/spec/requests/api/v1/clippings/index_spec.rb
@@ -49,6 +49,7 @@ describe 'GET /api/v1/clippings' do
     expect(payload[:news_ids]).to match_array(topic_one_news.map(&:id))
     expect(payload[:creator]).to include(:id, :name)
     expect(payload).not_to have_key(:topic_id)
+    expect(payload).to have_key(:reviewer)
   end
 
   it 'returns pagination metadata' do

--- a/spec/requests/api/v1/clippings/reports/update_spec.rb
+++ b/spec/requests/api/v1/clippings/reports/update_spec.rb
@@ -2,9 +2,9 @@
 
 describe 'PATCH /api/v1/clippings/:clipping_id/report' do
   subject(:request_update_report) do
-    patch api_v1_clipping_report_path(clipping), 
-          params: { clipping_report: report_params }, 
-          headers: auth_headers, 
+    patch api_v1_clipping_report_path(clipping),
+          params: { clipping_report: report_params },
+          headers: auth_headers,
           as: :json
   end
 

--- a/spec/requests/api/v1/clippings/update_spec.rb
+++ b/spec/requests/api/v1/clippings/update_spec.rb
@@ -45,6 +45,7 @@ describe 'PUT /api/v1/clippings/:id' do
       expect(json[:name]).to eq('Updated Summary')
       expect(json[:topic_id]).to eq(topic.id)
       expect(json[:news_ids]).to match_array(news.map(&:id))
+      expect(json[:reviewer_id]).to eq(admin_user.id)
     end
 
     context 'with invalid parameters' do
@@ -73,6 +74,7 @@ describe 'PUT /api/v1/clippings/:id' do
       request_update
       expect(response).to have_http_status(:ok)
       expect(json[:name]).to eq('Updated Summary')
+      expect(json[:reviewer_id]).to eq(regular_user.id)
     end
   end
 

--- a/spec/requests/api/v1/clippings/update_spec.rb
+++ b/spec/requests/api/v1/clippings/update_spec.rb
@@ -43,11 +43,8 @@ describe 'PUT /api/v1/clippings/:id' do
     it 'updates the clipping attributes', :aggregate_failures do
       request_update
       expect(json[:name]).to eq('Updated Summary')
-      expect(json[:topic]).to include(id: topic.id, name: topic.name)
-      expect(json[:news]).to be_an(Array)
-      expect(json[:news].pluck(:id)).to match_array(news.map(&:id))
-      expect(json).not_to have_key(:news_ids)
-      expect(json).not_to have_key(:topic_id)
+      expect(json[:topic_id]).to eq(topic.id)
+      expect(json[:news_ids]).to match_array(news.map(&:id))
     end
 
     context 'with invalid parameters' do

--- a/spec/requests/api/v1/clippings/update_spec.rb
+++ b/spec/requests/api/v1/clippings/update_spec.rb
@@ -43,8 +43,11 @@ describe 'PUT /api/v1/clippings/:id' do
     it 'updates the clipping attributes', :aggregate_failures do
       request_update
       expect(json[:name]).to eq('Updated Summary')
-      expect(json[:topic_id]).to eq(topic.id)
-      expect(json[:news_ids]).to match_array(news.map(&:id))
+      expect(json[:topic]).to include(id: topic.id, name: topic.name)
+      expect(json[:news]).to be_an(Array)
+      expect(json[:news].pluck(:id)).to match_array(news.map(&:id))
+      expect(json).not_to have_key(:news_ids)
+      expect(json).not_to have_key(:topic_id)
     end
 
     context 'with invalid parameters' do

--- a/spec/services/clippings/report_pdf_exporter_spec.rb
+++ b/spec/services/clippings/report_pdf_exporter_spec.rb
@@ -1,33 +1,33 @@
 RSpec.describe Clippings::ReportPdfExporter, type: :service do
   subject(:export_pdf) { described_class.call(report) }
-  
+
   let(:clipping) { create(:clipping, topic: create(:topic, name: 'Cultura')) }
   let(:markdown_content) do
     <<~MARKDOWN
       # Reporte de Clipping
-      
+
       ## Resumen Ejecutivo
-      
+
       Este es un reporte de prueba con **texto en negrita** y *cursiva*.
     MARKDOWN
   end
   let(:report) do
     create(:clipping_report, clipping: clipping, content: markdown_content)
   end
-  
+
   describe '.call' do
     it 'returns a successful result with PDF content' do
       result = export_pdf
-      
+
       expect(result).to be_success
       expect(result.payload[:content]).to be_present
       expect(result.payload[:filename]).to include('reporte_clipping_cultura')
       expect(result.payload[:filename]).to end_with('.pdf')
     end
-    
+
     it 'generates a valid PDF file' do
       result = export_pdf
-      
+
       # Verificar que el contenido comienza con el header de PDF
       expect(result.payload[:content]).to start_with('%PDF')
     end


### PR DESCRIPTION
En vez de topic_id se devuelve topic: {id, name}

Fixs de rubocop

En el show de clipping. se devuelve el array de noticias completo

En el create y update se devuelve el objeto clipping solamente con referencias a sus entidades relacionadas (topic_id, news_ids, etc) para evitar n+1.